### PR TITLE
Full gateway implementation

### DIFF
--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -370,5 +370,37 @@ module Discord
       def initialize(@opcode : Int64?, @sequence : Int64?, @data : MemoryIO, @event_type : String?)
       end
     end
+
+    class Session
+      getter session_id
+      property sequence
+
+      def initialize(@session_id : String)
+        @sequence = 0
+
+        @suspended = false
+        @invalid = false
+      end
+
+      def suspend
+        @suspended = true
+      end
+
+      def suspended? : Bool
+        @suspended
+      end
+
+      def invalidate
+        @invalid = true
+      end
+
+      def invalid? : Bool
+        @invalid
+      end
+
+      def should_resume? : Bool
+        suspended? && !invalid?
+      end
+    end
   end
 end

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -10,21 +10,35 @@ module Discord
 
     property cache : Cache?
 
+    @websocket : HTTP::WebSocket
+
     def initialize(@token : String, @client_id : UInt64)
+      @websocket = initialize_websocket
+    end
+
+    def run
+      loop do
+        @websocket.run
+
+        puts "Reconnecting"
+
+        @websocket = initialize_websocket
+      end
+    end
+
+    private def initialize_websocket : HTTP::WebSocket
       url = URI.parse(get_gateway.url)
-      @websocket = HTTP::WebSocket.new(
+      websocket = HTTP::WebSocket.new(
         host: url.host.not_nil!,
         path: "#{url.path}/?encoding=json&v=6",
         port: 443,
         tls: true
       )
 
-      @websocket.on_message(&->on_message(String))
-      @websocket.on_close(&->on_close(String))
-    end
+      websocket.on_message(&->on_message(String))
+      websocket.on_close(&->on_close(String))
 
-    def run
-      @websocket.run
+      websocket
     end
 
     private def on_close(message : String)

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -74,6 +74,8 @@ module Discord
           handle_dispatch(packet.event_type, packet.data)
         when OP_RECONNECT
           handle_reconnect
+        when OP_INVALID_SESSION
+          handle_invalid_session
         else
           puts "Unsupported message: #{message}"
         end
@@ -349,6 +351,11 @@ module Discord
 
       # Suspend the session so we 1. resume and 2. don't send heartbeats
       @session.try &.suspend
+    end
+
+    private def handle_invalid_session
+      @session.try &.invalidate
+      identify
     end
 
     # :nodoc:

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -77,6 +77,12 @@ module Discord
       nil
     end
 
+    # Injects a JSON *message* into the packet handler. Must be a valid gateway
+    # packet, including opcode, sequence and type.
+    def inject(message)
+      on_message(message)
+    end
+
     private def parse_message(message : String)
       parser = JSON::PullParser.new(message)
 

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -91,7 +91,7 @@ module Discord
       # Rewind to beginning of JSON
       data.rewind
 
-      GatewayPacket.new(opcode, sequence, data, event_type)
+      Gateway::GatewayPacket.new(opcode, sequence, data, event_type)
     end
 
     private def handle_hello(heartbeat_interval)
@@ -362,11 +362,13 @@ module Discord
     event voice_server_update, Gateway::VoiceServerUpdatePayload
   end
 
-  # :nodoc:
-  struct GatewayPacket
-    getter opcode, sequence, data, event_type
+  module Gateway
+    # :nodoc:
+    struct GatewayPacket
+      getter opcode, sequence, data, event_type
 
-    def initialize(@opcode : Int64 | Nil, @sequence : Int64 | Nil, @data : MemoryIO, @event_type : String | Nil)
+      def initialize(@opcode : Int64?, @sequence : Int64?, @data : MemoryIO, @event_type : String?)
+      end
     end
   end
 end

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -44,6 +44,9 @@ module Discord
     private def on_close(message : String)
       # TODO: make more sophisticated
       puts "Closed with: " + message
+
+      @session.try &.suspend
+      nil
     end
 
     OP_DISPATCH              =  0
@@ -162,6 +165,8 @@ module Discord
       case type
       when "READY"
         payload = Gateway::ReadyPayload.from_json(data)
+
+        @session = Gateway::Session.new(payload.session_id)
 
         @cache.try &.cache_current_user(payload.user)
 

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -72,6 +72,8 @@ module Discord
           handle_hello(payload.heartbeat_interval)
         when OP_DISPATCH
           handle_dispatch(packet.event_type, packet.data)
+        when OP_RECONNECT
+          handle_reconnect
         else
           puts "Unsupported message: #{message}"
         end
@@ -339,6 +341,14 @@ module Discord
       else
         puts "Unsupported dispatch: #{type} #{data}"
       end
+    end
+
+    private def handle_reconnect
+      # Close the websocket - the reconnection logic will kick in
+      @websocket.close
+
+      # Suspend the session so we 1. resume and 2. don't send heartbeats
+      @session.try &.suspend
     end
 
     # :nodoc:

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -32,8 +32,18 @@ module Discord
       puts "Closed with: " + message
     end
 
-    OP_DISPATCH =  0
-    OP_HELLO    = 10
+    OP_DISPATCH              =  0
+    OP_HEARTBEAT             =  1
+    OP_IDENTIFY              =  2
+    OP_STATUS_UPDATE         =  3
+    OP_VOICE_STATE_UPDATE    =  4
+    OP_VOICE_SERVER_PING     =  5
+    OP_RESUME                =  6
+    OP_RECONNECT             =  7
+    OP_REQUEST_GUILD_MEMBERS =  8
+    OP_INVALID_SESSION       =  9
+    OP_HELLO                 = 10
+    OP_HEARTBEAT_ACK         = 11
 
     private def on_message(message : String)
       spawn do

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -15,6 +15,42 @@ module Discord
       )
     end
 
+    struct IdentifyPacket
+      def initialize(token, properties, large_threshold, compress, shard)
+        @op = Discord::Client::OP_IDENTIFY
+        @d = IdentifyPayload.new(token, properties, large_threshold, compress, shard)
+      end
+
+      JSON.mapping(
+        op: Int32,
+        d: IdentifyPayload
+      )
+    end
+
+    struct IdentifyPayload
+      def initialize(@token, @properties, @compress, @large_threshold, @shard); end
+
+      JSON.mapping({
+        token: String,
+        properties: IdentifyProperties,
+        compress: Bool,
+        large_threshold: Int32,
+        shard: {type: {Int32, Int32}, nilable: true}
+      })
+    end
+
+    struct IdentifyProperties
+      def initialize(@os, @browser, @device, @referrer, @referring_domain); end
+
+      JSON.mapping(
+        os: {key: "$os", type: String},
+        browser: {key: "$browser", type: String},
+        device: {key: "$device", type: String},
+        referrer: {key: "$referrer", type: String},
+        referring_domain: {key: "$referring_domain", type: String}
+      )
+    end
+
     struct ResumePacket
       def initialize(token, session_id, seq)
         @op = Discord::Client::OP_RESUME

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -34,7 +34,8 @@ module Discord
     end
 
     struct IdentifyPayload
-      def initialize(@token, @properties, @compress, @large_threshold, @shard); end
+      def initialize(@token, @properties, @compress, @large_threshold, @shard)
+      end
 
       JSON.mapping({
         token: String,
@@ -46,7 +47,8 @@ module Discord
     end
 
     struct IdentifyProperties
-      def initialize(@os, @browser, @device, @referrer, @referring_domain); end
+      def initialize(@os, @browser, @device, @referrer, @referring_domain)
+      end
 
       JSON.mapping(
         os: {key: "$os", type: String},
@@ -71,7 +73,8 @@ module Discord
 
     # :nodoc:
     struct ResumePayload
-      def initialize(@token, @session_id, @seq); end
+      def initialize(@token, @session_id, @seq)
+      end
 
       JSON.mapping(
         token: String,
@@ -94,7 +97,8 @@ module Discord
 
     # :nodoc:
     struct StatusUpdatePayload
-      def initialize(@idle_since, @game); end
+      def initialize(@idle_since, @game)
+      end
 
       JSON.mapping(
         idle_since: {type: Int64, nilable: true, emit_null: true},
@@ -116,7 +120,8 @@ module Discord
 
     # :nodoc:
     struct VoiceStateUpdatePayload
-      def initialize(@guild_id, @channel_id, @self_mute, @self_deaf); end
+      def initialize(@guild_id, @channel_id, @self_mute, @self_deaf)
+      end
 
       JSON.mapping(
         guild_id: UInt64,
@@ -140,7 +145,8 @@ module Discord
 
     # :nodoc:
     struct RequestGuildMembersPayload
-      def initialize(@guild_id, @query, @limit); end
+      def initialize(@guild_id, @query, @limit)
+      end
 
       JSON.mapping(
         guild_id: UInt64,

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -15,6 +15,12 @@ module Discord
       )
     end
 
+    struct ResumedPayload
+      JSON.mapping(
+        _trace: Array(String)
+      )
+    end
+
     struct IdentifyPacket
       def initialize(token, properties, large_threshold, compress, shard)
         @op = Discord::Client::OP_IDENTIFY

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -15,6 +15,29 @@ module Discord
       )
     end
 
+    struct ResumePacket
+      def initialize(token, session_id, seq)
+        @op = Discord::Client::OP_RESUME
+        @d = ResumePayload.new(token, session_id, seq)
+      end
+
+      JSON.mapping(
+        op: Int32,
+        d: ResumePayload
+      )
+    end
+
+    # :nodoc:
+    struct ResumePayload
+      def initialize(@token, @session_id, @seq); end
+
+      JSON.mapping(
+        token: String,
+        session_id: String,
+        seq: Int64
+      )
+    end
+
     struct HelloPayload
       JSON.mapping(
         heartbeat_interval: UInt32,

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -74,6 +74,75 @@ module Discord
       )
     end
 
+    struct StatusUpdatePacket
+      def initialize(idle_since, game)
+        @op = Discord::Client::OP_STATUS_UPDATE
+        @d = StatusUpdatePayload.new(idle_since, game)
+      end
+
+      JSON.mapping(
+        op: Int32,
+        d: StatusUpdatePayload
+      )
+    end
+
+    # :nodoc:
+    struct StatusUpdatePayload
+      def initialize(@idle_since, @game); end
+
+      JSON.mapping(
+        idle_since: {type: Int64, nilable: true, emit_null: true},
+        game: {type: GamePlaying, nilable: true, emit_null: true}
+      )
+    end
+
+    struct VoiceStateUpdatePacket
+      def initialize(guild_id, channel_id, self_mute, self_deaf)
+        @op = Discord::Client::OP_VOICE_STATE_UPDATE
+        @d = VoiceStateUpdatePayload.new(guild_id, channel_id, self_mute, self_deaf)
+      end
+
+      JSON.mapping(
+        op: Int32,
+        d: VoiceStateUpdatePayload
+      )
+    end
+
+    # :nodoc:
+    struct VoiceStateUpdatePayload
+      def initialize(@guild_id, @channel_id, @self_mute, @self_deaf); end
+
+      JSON.mapping(
+        guild_id: UInt64,
+        channel_id: {type: UInt64, nilable: true, emit_null: true},
+        self_mute: Bool,
+        self_deaf: Bool
+      )
+    end
+
+    struct RequestGuildMembersPacket
+      def initialize(guild_id, query, limit)
+        @op = Discord::Client::OP_REQUEST_GUILD_MEMBERS
+        @d = RequestGuildMembersPayload.new(guild_id, query, limit)
+      end
+
+      JSON.mapping(
+        op: Int32,
+        d: RequestGuildMembersPayload
+      )
+    end
+
+    # :nodoc:
+    struct RequestGuildMembersPayload
+      def initialize(@guild_id, @query, @limit); end
+
+      JSON.mapping(
+        guild_id: UInt64,
+        query: String,
+        limit: Int32
+      )
+    end
+
     struct HelloPayload
       JSON.mapping(
         heartbeat_interval: UInt32,

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -126,7 +126,8 @@ module Discord
   end
 
   struct GamePlaying
-    def initialize(@name = nil, @type = nil, @url = nil); end
+    def initialize(@name = nil, @type = nil, @url = nil)
+    end
 
     JSON.mapping(
       name: {type: String, nilable: true},

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -126,6 +126,8 @@ module Discord
   end
 
   struct GamePlaying
+    def initialize(@name = nil, @type = nil, @url = nil); end
+
     JSON.mapping(
       name: {type: String, nilable: true},
       type: {type: UInt8, nilable: true},


### PR DESCRIPTION
Previously, the gateway implementation was very basic, only supporting (apart from dispatches) `HELLO`, `IDENTIFY`, and heartbeats. Now it supports the entire protocol except for `HEARTBEAT_ACK`, which may be done in the future once the rest of the lib is tested stable.