### PR TITLE
Fix the format for converting discords Timestamps to Time

### DIFF
--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -8,7 +8,7 @@ module Discord
       id: {type: UInt64, converter: SnowflakeConverter},
       channel_id: {type: UInt64, converter: SnowflakeConverter},
       author: User,
-      timestamp: {type: Time, converter: Time::Format::ISO_8601_DATE},
+      timestamp: {type: Time, converter: DATE_FORMAT},
       tts: Bool,
       mention_everyone: Bool,
       mentions: Array(User),

--- a/src/discordcr/mappings/converters.cr
+++ b/src/discordcr/mappings/converters.cr
@@ -2,6 +2,8 @@ require "json"
 require "time/format"
 
 module Discord
+  DATE_FORMAT = Time::Format.new("%FT%T.%L%:z")
+
   # :nodoc:
   module SnowflakeConverter
     def self.from_json(parser : JSON::PullParser) : UInt64

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -224,7 +224,7 @@ module Discord
         user: User,
         nick: {type: String, nilable: true},
         roles: {type: Array(UInt64), converter: SnowflakeArrayConverter},
-        joined_at: {type: Time?, converter: Time::Format::ISO_8601_DATE},
+        joined_at: {type: Time?, converter: DATE_FORMAT},
         deaf: Bool,
         mute: Bool,
         guild_id: {type: UInt64, converter: SnowflakeConverter}
@@ -274,7 +274,7 @@ module Discord
         id: {type: UInt64, converter: SnowflakeConverter},
         channel_id: {type: UInt64, converter: SnowflakeConverter},
         author: {type: User, nilable: true},
-        timestamp: {type: Time, nilable: true, converter: Time::Format::ISO_8601_DATE},
+        timestamp: {type: Time, nilable: true, converter: DATE_FORMAT},
         tts: {type: Bool, nilable: true},
         mention_everyone: {type: Bool, nilable: true},
         mentions: {type: Array(User), nilable: true},


### PR DESCRIPTION
(I'm just assuming that discord uses the same formatting for time in the Gateway)