### PR TITLE
Basic voice sending

### DIFF
--- a/examples/voice_send.cr
+++ b/examples/voice_send.cr
@@ -1,0 +1,130 @@
+# This is a simple music bot that can connect to a voice channel and play back
+# some music in DCA format. It demonstrates how to use VoiceClient and
+# DCAParser.
+#
+# For more information on the DCA file format, see
+# https://github.com/bwmarrin/dca.
+
+require "../src/discordcr"
+
+# Make sure to replace this fake data with actual data when running.
+client = Discord::Client.new(token: "Bot MjI5NDU5NjgxOTU1NjUyMzM3.Cpnz31.GQ7K9xwZtvC40y8MPY3eTqjEIXm", client_id: 229459681955652337_u64)
+
+# ID of the current user, required to create a voice client
+current_user_id = nil
+
+# The ID of the (text) channel in which the connect command was run, so the
+# "Voice connected." message is sent to the correct channel
+connect_channel_id = nil
+
+# Where the created voice client will eventually be stored
+voice_client = nil
+
+client.on_ready do |payload|
+  current_user_id = payload.user.id
+end
+
+client.on_message_create do |payload|
+  if payload.content.starts_with? "!connect "
+    # Used as:
+    # !connect <guild ID> <channel ID>
+
+    # Parse the command arguments
+    ids = payload.content[9..-1].split(' ').map(&.to_u64)
+
+    client.create_message(payload.channel_id, "Connecting...")
+    connect_channel_id = payload.channel_id
+    client.voice_state_update(ids[0].to_u64, ids[1].to_u64, false, false)
+  elsif payload.content.starts_with? "!play_dca "
+    # Used as:
+    # !play_dca <filename>
+    #
+    # Make sure the DCA file you play back is valid according to the spec
+    # (including metadata), otherwise playback will fail.
+
+    unless voice_client
+      client.create_message(payload.channel_id, "Voice client is nil!")
+      next
+    end
+
+    filename = payload.content[10..-1]
+    file = File.open(filename)
+
+    # The DCAParser class handles parsing of the DCA file. It doesn't do any
+    # sending of audio data to Discord itself – that has to be done by
+    # VoiceClient.
+    parser = Discord::DCAParser.new(file)
+
+    # A proper DCA(1) file contains metadata, which is exposed by DCAParser.
+    # This metadata may be of interest, so here is some example code that uses
+    # it.
+    if metadata = parser.metadata
+      tool = metadata.dca.tool
+      client.create_message(payload.channel_id, "DCA file was created by #{tool.name}, version #{tool.version}.")
+
+      if info = metadata.info
+        client.create_message(payload.channel_id, "Song info: #{info.title} by #{info.artist}.") if info.title && info.artist
+      end
+    else
+      client.create_message(payload.channel_id, "DCA file metadata is invalid!")
+    end
+
+    # Set the bot as speaking (green circle). This is important and has to be
+    # done at least once in every voice connection, otherwise the Discord client
+    # will not know who the packets we're sending belongs to.
+    voice_client.not_nil!.send_speaking(true)
+
+    client.create_message(payload.channel_id, "Playing DCA file `#{filename}`.")
+
+    # For smooth audio streams Discord requires one packet every
+    # 20 milliseconds. The `every` method measures the time it takes to run the
+    # block and then sleeps 20 milliseconds minus that time before moving on to
+    # the next iteration, ensuring accurate timing.
+    #
+    # When simply reading from DCA, the time it takes to read, process and
+    # send the frame is small enough that `every` doesn't make much of a
+    # difference (in fact, some users report that it actually makes things
+    # worse). If the processing time is not negligibly slow because you're
+    # doing something else than DCA parsing, or because you're reading from a
+    # slow source, or for any other reason, then it is recommended to use
+    # `every`. Otherwise, simply using a loop and `sleep`ing `20.milliseconds`
+    # each time may suffice.
+    Discord.every(20.milliseconds) do
+      frame = parser.next_frame(reuse_buffer: true)
+      break unless frame
+
+      # Perform the actual sending of the frame to Discord.
+      voice_client.not_nil!.play_opus(frame)
+    end
+
+    # Alternatively, the above code can be realised as the following:
+    #
+    # parser.parse do |frame|
+    #   Discord.timed_run(20.milliseconds) do
+    #     voice_client.not_nil!.play_opus(frame)
+    #   end
+    # end
+    #
+    # (The `parse` method reads the frames consecutively and passes them to the
+    # block.)
+
+    file.close
+  end
+end
+
+# The VOICE_SERVER_UPDATE dispatch is sent by Discord once the op4 packet sent
+# by voice_state_update has been processed. It tells the client the endpoint
+# to connect to.
+client.on_voice_server_update do |payload|
+  begin
+    vc = voice_client = Discord::VoiceClient.new(payload, client.session.not_nil!, current_user_id.not_nil!)
+    vc.on_ready do
+      client.create_message(connect_channel_id.not_nil!, "Voice connected.")
+    end
+    vc.run
+  rescue e
+    e.inspect_with_backtrace(STDOUT)
+  end
+end
+
+client.run

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -23,6 +23,10 @@ module Discord
     # the client receives the corresponding gateway dispatches.
     property cache : Cache?
 
+    # The internal *session* the client is currently using, necessary to create
+    # a voice client, for example
+    getter session : Gateway::Session?
+
     @websocket : Discord::WebSocket
 
     # Default analytics properties sent in IDENTIFY

--- a/src/discordcr/dca.cr
+++ b/src/discordcr/dca.cr
@@ -1,0 +1,150 @@
+require "json"
+
+module Discord
+  # Parser for the DCA file format, a simple wrapper around Opus made
+  # specifically for Discord bots.
+  class DCAParser
+    # Magic string that identifies a DCA1 file
+    DCA1_MAGIC = "DCA1"
+
+    # The parsed metadata, or nil if it could not be parsed.
+    getter metadata : DCA1Mappings::Metadata?
+
+    # Create a new parser. It will read from the given *io*. If *raw* is set,
+    # the file is assumed to be a DCA0 file, without any metadata. If the file's
+    # metadata doesn't conform to the DCA1 specification and *strict_metadata*
+    # is set, then the parsing will fail with an error; if it is not set then
+    # the metadata will silently be `nil`.
+    def initialize(@io : IO, raw = false, @strict_metadata = true)
+      unless raw
+        verify_magic
+        parse_metadata
+      end
+    end
+
+    # Reads the next frame from the IO. If there is nothing left to read, it
+    # will return `nil`.
+    #
+    # If *reuse_buffer* is true, a large buffer will be allocated once and
+    # reused for future calls of this method, reducing the load on the GC and
+    # potentially reusing memory use overall; if it is false, a new buffer of
+    # just the correct size will be allocated every time. Note that if the
+    # buffer is reused, the returned data is only valid until the next call to
+    # `next_frame`.
+    def next_frame(reuse_buffer = false) : Bytes?
+      begin
+        header = @io.read_bytes(Int16, IO::ByteFormat::LittleEndian)
+        raise "Negative frame header (#{header} < 0)" if header < 0
+
+        buf = if reuse_buffer
+                full_buf = @reused_buffer ||= Bytes.new(Int16::MAX)
+                full_buf[0, header]
+              else
+                Bytes.new(header)
+              end
+
+        @io.read_fully(buf)
+        buf
+      rescue IO::EOFError
+        nil
+      end
+    end
+
+    # Continually reads frames from the IO until there are none left. Each frame
+    # is passed to the given *block*.
+    def parse(&block : Bytes ->)
+      loop do
+        buf = next_frame
+
+        if buf
+          block.call(buf)
+        else
+          break
+        end
+      end
+    end
+
+    private def verify_magic
+      magic = @io.read_string(4)
+      if magic != DCA1_MAGIC
+        raise "File is not a DCA1 file (magic is #{magic}, should be DCA1)"
+      end
+    end
+
+    private def parse_metadata
+      # The header of the metadata part is the four-byte size of the following
+      # metadata payload.
+      metadata_size = @io.read_bytes(Int32, IO::ByteFormat::LittleEndian)
+      metadata_io = IO::Sized.new(@io, read_size: metadata_size)
+
+      begin
+        @metadata = DCA1Mappings::Metadata.from_json(metadata_io)
+      rescue e : JSON::ParseException
+        raise e if @strict_metadata
+      end
+
+      metadata_io.skip_to_end
+    end
+  end
+
+  # Mappings for DCA1 metadata
+  module DCA1Mappings
+    struct Metadata
+      JSON.mapping(
+        dca: DCA,
+        opus: Opus,
+        info: {type: Info, nilable: true},
+        origin: {type: Origin, nilable: true},
+        extra: JSON::Any
+      )
+    end
+
+    struct DCA
+      JSON.mapping(
+        version: Int32,
+        tool: Tool
+      )
+    end
+
+    struct Tool
+      JSON.mapping(
+        name: String,
+        version: String,
+        url: {type: String, nilable: true},
+        author: {type: String, nilable: true}
+      )
+    end
+
+    struct Opus
+      JSON.mapping(
+        mode: String,
+        sample_rate: Int32,
+        frame_size: Int32,
+        abr: Int32?,
+        vbr: Bool,
+        channels: Int32
+      )
+    end
+
+    struct Info
+      JSON.mapping(
+        title: {type: String, nilable: true},
+        artist: {type: String, nilable: true},
+        album: {type: String, nilable: true},
+        genre: {type: String, nilable: true},
+        comments: {type: String, nilable: true},
+        cover: {type: String, nilable: true}
+      )
+    end
+
+    struct Origin
+      JSON.mapping(
+        source: {type: String, nilable: true},
+        abr: {type: Int32, nilable: true},
+        channels: {type: Int32, nilable: true},
+        encoding: {type: String, nilable: true},
+        url: {type: String, nilable: true}
+      )
+    end
+  end
+end

--- a/src/discordcr/mappings/vws.cr
+++ b/src/discordcr/mappings/vws.cr
@@ -1,0 +1,106 @@
+require "./converters"
+
+module Discord
+  # :nodoc:
+  module VWS
+    struct IdentifyPacket
+      def initialize(server_id, user_id, session_id, token)
+        @op = Discord::VoiceClient::OP_IDENTIFY
+        @d = IdentifyPayload.new(server_id, user_id, session_id, token)
+      end
+
+      JSON.mapping(
+        op: Int32,
+        d: IdentifyPayload
+      )
+    end
+
+    struct IdentifyPayload
+      def initialize(@server_id, @user_id, @session_id, @token)
+      end
+
+      JSON.mapping(
+        server_id: UInt64,
+        user_id: UInt64,
+        session_id: String,
+        token: String
+      )
+    end
+
+    struct SelectProtocolPacket
+      def initialize(protocol, data)
+        @op = Discord::VoiceClient::OP_SELECT_PROTOCOL
+        @d = SelectProtocolPayload.new(protocol, data)
+      end
+
+      JSON.mapping(
+        op: Int32,
+        d: SelectProtocolPayload
+      )
+    end
+
+    struct SelectProtocolPayload
+      def initialize(@protocol, @data)
+      end
+
+      JSON.mapping(
+        protocol: String,
+        data: ProtocolData
+      )
+    end
+
+    struct ProtocolData
+      def initialize(@address, @port, @mode)
+      end
+
+      JSON.mapping(
+        address: String,
+        port: UInt16,
+        mode: String
+      )
+    end
+
+    struct ReadyPayload
+      JSON.mapping(
+        ssrc: Int32,
+        port: Int32,
+        modes: Array(String),
+        heartbeat_interval: Int32
+      )
+    end
+
+    struct SessionDescriptionPayload
+      JSON.mapping(
+        secret_key: Array(UInt8)
+      )
+    end
+
+    struct SpeakingPacket
+      def initialize(speaking, delay)
+        @op = Discord::VoiceClient::OP_SPEAKING
+        @d = SpeakingPayload.new(speaking, delay)
+      end
+
+      JSON.mapping(
+        op: Int32,
+        d: SpeakingPayload
+      )
+    end
+
+    struct SpeakingPayload
+      def initialize(@speaking, @delay)
+      end
+
+      JSON.mapping(
+        speaking: Bool,
+        delay: Int32
+      )
+    end
+
+    struct HelloPayload
+      JSON.mapping(
+        heartbeat_interval: Int32
+      )
+    end
+  end
+end

--- a/src/discordcr/sodium.cr
+++ b/src/discordcr/sodium.cr
@@ -1,0 +1,22 @@
+module Discord
+  # Bindings to libsodium. These aren't intended to be general bindings, just
+  # for the specific xsalsa20poly1305 encryption Discord uses.
+  @[Link("sodium")]
+  lib Sodium
+    # Encrypt something using xsalsa20poly1305
+    fun crypto_secretbox_xsalsa20poly1305(c : UInt8*, message : UInt8*,
+                                          mlen : UInt64, nonce : UInt8*,
+                                          key : UInt8*) : LibC::Int
+
+    # Decrypt something using xsalsa20poly1305 ("open a secretbox")
+    fun crypto_secretbox_xsalsa20poly1305_open(message : UInt8*, c : UInt8*,
+                                               mlen : UInt64, nonce : UInt8*,
+                                               key : UInt8*) : LibC::Int
+
+    # Constants
+    fun crypto_secretbox_xsalsa20poly1305_keybytes : LibC::SizeT     # Key size in bytes
+    fun crypto_secretbox_xsalsa20poly1305_noncebytes : LibC::SizeT   # Nonce size in bytes
+    fun crypto_secretbox_xsalsa20poly1305_zerobytes : LibC::SizeT    # Zero bytes before a plaintext
+    fun crypto_secretbox_xsalsa20poly1305_boxzerobytes : LibC::SizeT # Zero bytes before a ciphertext
+  end
+end

--- a/src/discordcr/voice.cr
+++ b/src/discordcr/voice.cr
@@ -269,4 +269,30 @@ module Discord
       c + box_zero_bytes
     end
   end
+
+  # Utility function that runs the given block and measures the time it takes,
+  # then sleeps the given time minus that time. This is useful for voice code
+  # because (in most cases) voice data should be sent to Discord at a rate of
+  # one frame every 20 ms, and if the processing and sending takes a certain
+  # amount of time, then noticeable choppiness can be heard.
+  def self.timed_run(total_time : Time::Span)
+    t1 = Time.now
+    yield
+    delta = Time.now - t1
+
+    sleep_time = {total_time - delta, Time::Span.zero}.max
+    sleep sleep_time
+  end
+
+  # Runs the given block every *time_span*. This method takes into account the
+  # execution time for the block to keep the intervals accurate.
+  #
+  # Note that if the block takes longer to execute than the given *time_span*,
+  # there will be no delay: the next iteration follows immediately, with no
+  # attempt to get in sync.
+  def self.every(time_span : Time::Span)
+    loop do |i|
+      timed_run(time_span) { yield }
+    end
+  end
 end

--- a/src/discordcr/websocket.cr
+++ b/src/discordcr/websocket.cr
@@ -1,0 +1,70 @@
+require "http"
+
+module Discord
+  # Internal wrapper around HTTP::WebSocket to decode the Discord-specific
+  # payload format used in the gateway and VWS.
+  class WebSocket
+    # :nodoc:
+    struct Packet
+      getter opcode, sequence, data, event_type
+
+      def initialize(@opcode : Int64?, @sequence : Int64?, @data : IO::Memory, @event_type : String?)
+      end
+    end
+
+    def initialize(@host : String, @path : String, @port : Int32, @tls : Bool)
+      @websocket = HTTP::WebSocket.new(
+        host: @host,
+        path: @path,
+        port: @port,
+        tls: @tls
+      )
+    end
+
+    def on_message(&handler : Packet ->)
+      @websocket.on_message do |message|
+        payload = parse_message(message)
+        handler.call(payload)
+      end
+    end
+
+    def on_close(&handler : String ->)
+      @websocket.on_close(&handler)
+    end
+
+    delegate run, close, send, to: @websocket
+
+    private def parse_message(message : String)
+      parser = JSON::PullParser.new(message)
+
+      opcode = nil
+      sequence = nil
+      event_type = nil
+      data = IO::Memory.new
+
+      parser.read_object do |key|
+        case key
+        when "op"
+          opcode = parser.read_int
+        when "d"
+          # Read the raw JSON into memory
+          JSON.build(data) do |builder|
+            parser.read_raw(builder)
+          end
+        when "s"
+          sequence = parser.read_int_or_null
+        when "t"
+          event_type = parser.read_string_or_null
+        else
+          # Unknown field
+          parser.skip
+        end
+      end
+
+      # Rewind to beginning of JSON
+      data.rewind
+
+      Packet.new(opcode, sequence, data, event_type)
+    end
+  end
+end


### PR DESCRIPTION
This is a fully working implementation of voice sending to Discord. I have tested it and it worked without problems, however it would be useful if others would test this on their systems, given that it introduces a native dependency.

So far, only sending already-encoded Opus frames is supported, ~~and there is no automatic timing – the timing has to be done manually.~~ **(Automatic timing has been implemented)**

It should be used approximately like this **(Out of date, see the included example for a working demo)**:

```cr
# somewhere
client.voice_state_update(guild_id, channel_id, false, false)

# A VOICE_SERVER_UPDATE dispatch is received as a response to the sent voice_state_update
client.on_voice_server_update do |payload|
  # The payload can be used to create a voice client
  voice_client = Discord::VoiceClient.new(payload, client.session, user_id)

  # Called on successful connection
  voice_client.on_ready do
    # Tell Discord that we are speaking (green circle in user list). This is
    # important and has to be done at least once in every connection, because
    # Discord uses this packet to tell its clients which SSRC belongs to whom.
    voice_client.send_speaking(true)

    loop do
      opus_data = magically_produce_an_opus_frame()
      voice_client.play_opus(opus_data)

      # This timing is slightly inaccurate; ideally the time it takes to send
      # the packet would be measured and then we would sleep 20 ms - that time.
      sleep 20.milliseconds
    end
  end
end
```

Questions:
- How many more abstractions should we provide? ~~Accurate timing, opus encoding, DCA reading, bindings to ffmpeg for playing arbitrary files? I'm thinking we should definitely do the first one, but the others probably don't fit the concept of the lib.~~ **We've decided on accurate timing and DCA reading**
- Should the `play_opus` method keep its name? ~~It's not the ideal name in my opinion but I 
can't really think of an alternative.~~ **Yes**
- Should `discordcr.cr` be changed to not automatically require `voice.cr`, so the user doesn't have to incur the libsodium dependency if they don't want voice? ~~I would say yes but I'm not sure how acceptable that is to do in Crystal.~~ **Crystal does this automatically if the user doesn't use voice code**