### PR TITLE
Fix #to_json in Converters

### DIFF
--- a/src/discordcr/mappings/converters.cr
+++ b/src/discordcr/mappings/converters.cr
@@ -25,7 +25,7 @@ module Discord
     end
 
     def self.to_json(value : UInt64, builder : JSON::Builder)
-      builder.puts(value.to_s)
+      builder.scalar(value.to_s)
     end
   end
 
@@ -43,9 +43,9 @@ module Discord
 
     def self.to_json(value : UInt64?, builder : JSON::Builder)
       if value
-        builder.puts(value.to_s)
+        builder.scalar(value.to_s)
       else
-        builder.puts("null")
+        builder.null
       end
     end
   end


### PR DESCRIPTION
This fixes `#to_json` on any mapping that used these converters.

The converter's `#to_json` methods called `Builder#puts` - this method doesn't exist. I did some light digging, and I actually can't find where it came from. 

