### PR TITLE
Message#parse_mentions

### DIFF
--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -18,10 +18,6 @@ module Discord
       pinned: {type: Bool, nilable: true}
     )
 
-    # A mention contained within a message, constructed by its type,
-    # the snowflake, and it's name if it is an emoji.
-    alias Mention = Tuple(MentionType, UInt64?, String?)
-
     # A hash map of regex describing how mentions are parsed by type
     MENTION_REGEX = {
       MentionType::User     => /<@!?(?<id>\d+)>/,
@@ -32,20 +28,12 @@ module Discord
       MentionType::Here     => /@here/,
     }
 
-    # Returns a map of all mentions contained in the message.
+    # Returns an array of all mentions contained in the message.
     def parse_mentions
-      mentions = {} of MentionType => Array(Mention)
+      mentions = [] of Mention
 
-      {% for typ in {
-                      MentionType::User,
-                      MentionType::Role,
-                      MentionType::Channel,
-                      MentionType::Emoji,
-                      MentionType::Everyone,
-                      MentionType::Here,
-                    } %}
-        mentions[MentionType.new({{typ}})] = parse_mentions(MentionType.new({{typ}}))
-      {% end %}
+      parse_mentions { |m| mentions << m }
+
       mentions
     end
 
@@ -65,6 +53,10 @@ module Discord
       end
     end
   end
+
+  # A mention contained within a message, constructed by its type,
+  # the snowflake, and its name if it is an emoji.
+  record Mention, type : MentionType, id : UInt64?, name : String?
 
   # An enum of the different kinds of Discord mentions
   enum MentionType


### PR DESCRIPTION
I went as best I could off of the talk / psuedocode in #35.

I didn't think it was really fitting to put it as a `self` method of `Discord` (`Discord.parse_mentions`) as `Message#content` is the only place they will ever occur.

I'm also not sure if [this is still desirable](https://github.com/meew0/discordcr/issues/35#issuecomment-254963274):
> [..] because you don't get their position in the string. 

I personally don't need it (did you mean the literal string index? and can't really think of a use case not covered by this PR, some kind of exotic parsing I guess?), but I can look into implementing it.

Also, not 100% sure how I feel about the overload `def parse_mentions(typ : MentionType)`.

Example usage: **(out of date, see diff)**
```crystal
msg = client.get_channel_message(246283902652645376u64, 313536439444832257u64)

msg.parse_mentions do |kind, id, name|
  case kind
  when Discord::MentionType::User
    puts "User mentioned: #{id}"
  when Discord::MentionType::Channel
    puts "Channel mentioned: #{id}"
  when Discord::MentionType::Role
    puts "Role mentioned: #{id}"
  when Discord::MentionType::Emoji
    puts "Emoji mentioned: #{name}:#{id}"
  when Discord::MentionType::Everyone
    puts "Everyone mentioned"
  when Discord::MentionType::Here
    puts "Here mentioned"
  end
end
# => User mentioned: 120571255635181568
# => User mentioned: 225375446223683606
# => Role mentioned: 244951251865960449
# => Channel mentioned: 225375815087554563
# => Emoji mentioned: old_man:246811049834053632
# => Everyone mentioned
# => Here mentioned

p msg.parse_mentions
# #=> {User => [{User, 120571255635181568, nil}, {User, 225375446223683606, nil}],
#       Role => [{Role, 244951251865960449, nil}],
#       Channel => [{Channel, 225375815087554563, nil}],
#       Emoji => [{Emoji, 246811049834053632, "old_man"}],
#       Everyone => [{Everyone, nil, nil}],
#       Here => [{Here, nil, nil}]}

p msg.parse_mentions(Discord::MentionType::User)
# => [{User, 120571255635181568, nil}, {User, 225375446223683606, nil}]
```

Closes #35 