### PR TITLE
Remove REST#query_users, REST#accept_invite

### DIFF
--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -1091,22 +1091,6 @@ module Discord
       User.from_json(response.body)
     end
 
-    # Queries users by username.
-    #
-    # [API docs for this method](https://discordapp.com/developers/docs/resources/user#query-users)
-    def query_users(query : String, limit : Int32 = 25)
-      response = request(
-        :users,
-        nil,
-        "GET",
-        "/users?q=#{query}&limit=#{limit}",
-        HTTP::Headers.new,
-        nil
-      )
-
-      Array(User).from_json(response.body)
-    end
-
     # Gets the current bot user.
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/user#get-current-user)

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -1241,8 +1241,13 @@ module Discord
       Invite.from_json(response.body)
     end
 
-    # Makes the user accept an invite. Will not work for bots.
-    #
+    # Makes a user accept an invite. Will not work for bots.
+    # For example, this can be used with a `Client` instantiated with an OAuth2
+    # `Bearer` token that has been granted the `guilds.join` scope.
+    # ```
+    # client = Discord::Client.new token: "Bearer XYZ"
+    # client.accept_invite("ABCdef")
+    # ```
     # [API docs for this method](https://discordapp.com/developers/docs/resources/invite#accept-invite)
     def accept_invite(code : String)
       response = request(


### PR DESCRIPTION
- The query endpoint no longer exists.

- The scope of this library is not aimed at user bots, so I'm not sure why the accept invite endpoint was included.