### PR TITLE
Fix status updates being mostly broken

### DIFF
--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -242,7 +242,7 @@ module Discord
     # *afk* can be used in conjunction to signify to Discord that the status
     # change is due to inactivity on the bot's part – this fulfills no cosmetic
     # purpose.
-    def status_update(status : String? = nil, game : GamePlaying? = nil, afk : Bool = false, since : Int64 = 0_i64)
+    def status_update(status : String? = nil, game : GamePlaying? = nil, afk : Bool = false, since : Int64? = nil)
       packet = Gateway::StatusUpdatePacket.new(status, game, afk, since)
       @websocket.send(packet.to_json)
     end

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -104,7 +104,7 @@ module Discord
         status: {type: String, nilable: true, emit_null: true},
         game: {type: GamePlaying, nilable: true, emit_null: true},
         afk: Bool,
-        since: Int64
+        since: {type: Int64, nilable: true, emit_null: true}
       )
     end
 


### PR DESCRIPTION
Apparently Discord is very specific about the `since` field: if it is 0 it is treated differently from being null, causing unpredictable behaviour. Now it is null by default. Fixes #71.