### PR TITLE
Member cache fixes, and getters for cache hashes

### DIFF
--- a/src/discordcr/cache.cr
+++ b/src/discordcr/cache.cr
@@ -33,6 +33,42 @@ module Discord
   # likely to occur, a client without a gateway connection should probably
   # refrain from caching at all.
   class Cache
+    # A map of cached users. These aren't necessarily all the users in servers
+    # the bot has access to, but rather all the users that have been seen by
+    # the bot in the past (and haven't been deleted by means of `delete_user`).
+    getter users
+
+    # A map of cached channels, i. e. all channels on all servers the bot is on,
+    # as well as all DM channels.
+    getter channels
+
+    # A map of guilds (servers) the bot is on. Doesn't ignore guilds temporarily
+    # deleted due to an outage; so if an outage is going on right now the
+    # affected guilds would be missing here too.
+    getter guilds
+
+    # A double map of members on servers, represented as {guild ID => {user ID
+    # => member}}. Will only contain previously and currently online members as
+    # well as all members that have been chunked (see
+    # `Client#request_guild_members`).
+    getter members
+
+    # A map of all roles on servers the bot is on. Does not discriminate by
+    # guild, as role IDs are unique even across guilds.
+    getter roles
+
+    # Mapping of users to the respective DM channels the bot has open with them,
+    # represented as {user ID => channel ID}.
+    getter dm_channels
+
+    # Mapping of guilds to the roles on them, represented as {guild ID =>
+    # [role IDs]}.
+    getter guild_roles
+
+    # Mapping of guilds to the channels on them, represented as {guild ID =>
+    # [channel IDs]}.
+    getter guild_channels
+
     # Creates a new cache with a *client* that requests (in case of cache
     # misses) should be done on.
     def initialize(@client : Client)

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -431,6 +431,11 @@ module Discord
           @cache.try &.add_guild_role(guild.id, role.id)
         end
 
+        payload.members.each do |member|
+          cache member.user
+          @cache.try &.cache(member, guild.id)
+        end
+
         call_event guild_create, payload
       when "GUILD_UPDATE"
         payload = Guild.from_json(data)

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -475,7 +475,7 @@ module Discord
         cache payload.user
         @cache.try do |c|
           member = c.resolve_member(payload.guild_id, payload.user.id)
-          new_member = GuildMember.new(member, payload.roles)
+          new_member = GuildMember.new(member, payload.roles, payload.nick)
           c.cache(new_member, payload.guild_id)
         end
 

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -253,6 +253,7 @@ module Discord
       JSON.mapping(
         user: User,
         roles: {type: Array(UInt64), converter: SnowflakeArrayConverter},
+        nick: {type: String, nilable: true},
         guild_id: {type: UInt64, converter: SnowflakeConverter}
       )
     end

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -68,10 +68,22 @@ module Discord
 
   struct GuildMember
     # :nodoc:
-    def initialize(payload : Gateway::GuildMemberAddPayload | GuildMember, roles : Array(UInt64)? = nil)
+    def initialize(payload : Gateway::GuildMemberAddPayload | GuildMember, roles : Array(UInt64), nick : String?)
+      # This redundant assignment is necessary because Crystal would otherwise
+      # erroneously assume @roles can be nil.
+      # TODO: Remove in Crystal 0.24.0 (crystal-lang/crystal#4830)
+      @roles = payload.roles
+
+      initialize(payload)
+      @nick = nick
+      @roles = roles
+    end
+
+    # :nodoc:
+    def initialize(payload : Gateway::GuildMemberAddPayload | GuildMember)
       @user = payload.user
       @nick = payload.nick
-      @roles = roles || payload.roles
+      @roles = payload.roles
       @joined_at = payload.joined_at
       @deaf = payload.deaf
       @mute = payload.mute


### PR DESCRIPTION
Fixes the two things mentioned in #60 — members and users from `GUILD_CREATE` not being cached, and missing getters for cache hashes. Also fixes a related bug uncovered during testing where nicks of cached members weren't updated properly.