### PR TITLE
Fix Travis tag builds being ignored for deployment

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -12,7 +12,7 @@ function doCompile {
 }
 
 # Pull requests and commits to other branches shouldn't try to deploy, just build to verify
-if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
+if [ "$TRAVIS_PULL_REQUEST" != "false" -o ["$TRAVIS_BRANCH" != "$SOURCE_BRANCH" && -z "$TRAVIS_TAG" ] ]; then
     echo "Skipping deploy; just doing a build."
     doCompile
     exit 0


### PR DESCRIPTION
Tag builds should of course be tested and deployed rather than just tested. Previously this case was missed during checking whether the deployment should be skipped.