### PR TITLE
Add missing User fields

### DIFF
--- a/src/discordcr/mappings/user.cr
+++ b/src/discordcr/mappings/user.cr
@@ -20,8 +20,7 @@ module Discord
       email: {type: String, nilable: true},
       bot: {type: Bool, nilable: true},
       mfa_enabled: {type: Bool, nilable: true},
-      verified: {type: Bool, nilable: true},
-      phone: {type: String, nilable: true}
+      verified: {type: Bool, nilable: true}
     )
   end
 

--- a/src/discordcr/mappings/user.cr
+++ b/src/discordcr/mappings/user.cr
@@ -18,7 +18,10 @@ module Discord
       discriminator: String,
       avatar: {type: String, nilable: true},
       email: {type: String, nilable: true},
-      bot: {type: Bool, nilable: true}
+      bot: {type: Bool, nilable: true},
+      mfa_enabled: {type: Bool, nilable: true},
+      verified: {type: Bool, nilable: true},
+      phone: {type: String, nilable: true}
     )
   end
 


### PR DESCRIPTION
Some fields which are only available for `/users/@me`. [Mostly taken from documentation](https://discordapp.com/developers/docs/resources/user#user-object-user-structure), the `phone` field found through messing around with Postman
![image](https://user-images.githubusercontent.com/4568670/29712359-beb7ac26-8999-11e7-969c-845819a29256.png)
