### PR TITLE
[WIP] Refactor Cache

### DIFF
--- a/src/discordcr/cache.cr
+++ b/src/discordcr/cache.cr
@@ -1,216 +1,241 @@
 require "./mappings/*"
 
-module Discord
-  # A cache is a utility class that stores various kinds of Discord objects,
-  # like `User`s, `Role`s etc. Its purpose is to reduce both the load on
-  # Discord's servers and reduce the latency caused by having to do an API call.
-  # It is recommended to use caching for bots that interact heavily with
-  # Discord-provided data, like for example administration bots, as opposed to
-  # bots that only interact by sending and receiving messages. For that latter
-  # kind, caching is usually even counter-productive as it only unnecessarily
-  # increases memory usage.
+# Caches are utility classes that stores various kinds of Discord objects, like `User`s, `Roles`, etc.
+# Its purpose is to reduce both the load on Discord's servers and reduce the latency caused by having
+# to do an API call. It is recommended to use caching for bots that interact heavily with Discord-provided
+# data, like for example administration bots, as opposed to bots that only interact by sending and receiving
+# messages. For that latter kind, caching is usually even counter-productive as it only unnecessarily
+# increases memory usage.
+#
+# This modules contains a basic in-memory cache, but also provides interfaces for you to build your own
+# custom cache class (see `TypeCache`) that may implement any other kind of store such as Redis or SQL ORDBMS.
+module Discord::Cache
+  # `TypeCache` is a generic interface that describes behavior for the storage of Discord-related objects.
+  # `TypeCache` behavior stores an object `V` by some unique identifier `K` (typically a UInt64 snowflake). 
+  # It is up to the user to implement the desired storage behavior.
+  # In the implementation of `#init_handlers`, the `TypeCache` is expected to register event handlers on the `Client`
+  # reference that will trigger cache-related actions to keep its resources up to date.
+  # Alternatively, the `TypeCache` can be used manually without or in addition to handling `Client` events.
   #
-  # Caching can either be used standalone, in a purely REST-based way:
+  # A simple implementation of an in-memory `Guild` cache may look like:
   # ```
-  # client = Discord::Client.new(token: "Bot token", client_id: 123_u64)
-  # cache = Discord::Cache.new(client)
+  # class GuildMemory
+  #   # Store guilds by their snowflake ID
+  #   include Discord::TypeCache(UInt64, Discord::Guild)
   #
-  # puts cache.resolve_user(66237334693085184) # will perform API call
-  # puts cache.resolve_user(66237334693085184) # will not perform an API call, as the data is now cached
-  # ```
+  #   # Include the template set of event handlers for guild-related events
+  #   include Discord::Handlers::Guild
   #
-  # It can also be integrated more deeply into a `Client` (specifically one that
-  # uses a gateway connection) to reduce cache misses even more by automatically
-  # caching data received over the gateway:
-  # ```
-  # client = Discord::Client.new(token: "Bot token", client_id: 123_u64)
-  # cache = Discord::Cache.new(client)
-  # client.cache = cache # Integrate the cache into the client
-  # ```
+  #   @guilds = {} of UInt64 => Discord::Guild
   #
-  # Note that if a cache is *not* used this way, its data will slowly go out of
-  # sync with Discord, and unless it is used in an environment with few changes
-  # likely to occur, a client without a gateway connection should probably
-  # refrain from caching at all.
-  class Cache
-    # Creates a new cache with a *client* that requests (in case of cache
-    # misses) should be done on.
-    def initialize(@client : Client)
-      @users = Hash(UInt64, User).new
-      @channels = Hash(UInt64, Channel).new
-      @guilds = Hash(UInt64, Guild).new
-      @members = Hash(UInt64, Hash(UInt64, GuildMember)).new
-      @roles = Hash(UInt64, Role).new
-
-      @dm_channels = Hash(UInt64, UInt64).new
-
-      @guild_roles = Hash(UInt64, Array(UInt64)).new
-      @guild_channels = Hash(UInt64, Array(UInt64)).new
+  #   def cache(id : UInt64, guild : Discord::Guild)
+  #     @guilds[id] = guild
+  #   end
+  #
+  #   def resolve?(id : UInt64)
+  #     @guilds[id]?
+  #   end
+  #
+  #   def remove(id : UInt64)
+  #     @guilds.delete(id)
+  #   end
+  # end
+  #
+  # cache = GuildMemory.new(client)
+  # ```
+  module TypeCache(K, V)
+    # Exception to raise when a member of a cache isn't found
+    class MissingMember < Exception
     end
 
-    # Resolves a user by its *ID*. If the requested object is not cached, it
-    # will do an API call.
-    def resolve_user(id : UInt64) : User
-      @users.fetch(id) { @users[id] = @client.get_user(id) }
+    def initialize(@client : Discord::Client)
+      init_handlers
     end
 
-    # Resolves a channel by its *ID*. If the requested object is not cached, it
-    # will do an API call.
-    def resolve_channel(id : UInt64) : Channel
-      @channels.fetch(id) { @channels[id] = @client.get_channel(id) }
+    # Stores the given `object` at `key`.
+    abstract def cache(key : K, object : V)
+
+    # Stores the given object, expecting that `object` responds to `#id`.
+    def cache(object : V)
+      cache(object.id, object)
     end
 
-    # Resolves a guild by its *ID*. If the requested object is not cached, it
-    # will do an API call.
-    def resolve_guild(id : UInt64) : Guild
-      @guilds.fetch(id) { @guilds[id] = @client.get_guild(id) }
+    # Removes a member from this cache from its `key`.
+    abstract def remove(key : K)
+
+    # Removes a member, expecting that `object` responds to `#id`.
+    def remove(object : V)
+      remove(object.id)
     end
 
-    # Resolves a member by the *guild_id* of the guild the member is on, and the
-    # *user_id* of the member itself. An API request will be performed if the
-    # object is not cached.
-    def resolve_member(guild_id : UInt64, user_id : UInt64) : GuildMember
-      local_members = @members[guild_id] ||= Hash(UInt64, GuildMember).new
-      local_members.fetch(user_id) { local_members[user_id] = @client.get_guild_member(guild_id, user_id) }
+    # Resolves the cache memeber from `key`.
+    abstract def resolve?(key : K)
+
+    # Resolves the cache member from `key`.
+    # Raises an exception if the member isn't found instead of making a request.
+    def resolve(key : K)
+      member = resolve?(key)
+      raise MissingMember.new("Cache member not present with key: #{key}") unless member
+
+      member
     end
 
-    # Resolves a role by its *ID*. No API request will be performed if the role
-    # is not cached, because there is no endpoint for individual roles; however
-    # all roles should be cached at all times so it won't be a problem.
-    def resolve_role(id : UInt64) : Role
-      @roles[id] # There is no endpoint for getting an individual role, so we will have to ignore that case for now.
+    # Registers handlers on this cache's `Client` to manage its stored data
+    abstract def init_handlers
+  end
+
+  # Container for multiple `TypeCache` objects that maps Discord types to a `TypeCache`
+  class CacheSet
+    # The `Client` to pass to the caches to register their handlers on after initialization
+    getter client : Client
+
+    def initialize(@client)
     end
 
-    # Resolves the ID of a DM channel with a particular user by the recipient's
-    # *recipient_id*. If there is no such channel cached, one will be created.
-    def resolve_dm_channel(recipient_id : UInt64) : UInt64
-      @dm_channels.fetch(recipient_id) do
-        channel = @client.create_dm(recipient_id)
-        cache(Channel.new(channel))
-        channel.id
+    # The different possible cache types
+    TYPES = {
+      guild:        {key: UInt64, type: Guild},
+      guild_member: {key: {UInt64, UInt64}, type: GuildMember},
+      channel:      {key: UInt64, type: Channel},
+      role:         {key: {UInt64, UInt64}, type: Role},
+      users:        {key: UInt64, type: User},
+    }
+
+    {% begin %}
+      {% for key, properties in TYPES %}
+        # Cache for `{{properties[:type]}}` objects
+        property {{key}} : TypeCache({{properties[:key]}}, {{properties[:type]}})?
+
+        def [](type : {{properties[:type]}}.class)
+          @{{key}}
+        end
+      {% end %}
+
+      # Assigns multiple `TypeCache` at once
+      def configure({{TYPES.map { |key, properties| "#{key} : TypeCache(#{properties[:key]}, #{properties[:type]}).class | Nil = nil".id }.splat}})
+        {% for key in TYPES %}
+          @{{key}} = {{key}}.try &.new(client)
+        {% end %}
+      end
+    {% end %}
+  end
+
+  # This module provides a template set of handlers for easily creating custom `Cache`
+  # classes that respond to common gateway events.
+  # Each module defines `Cache#init_handlers`.
+  module Handlers
+    # Handlers for `Guild`-related gateway events.
+    module Guild
+      def init_handlers
+        @client.on_guild_create do |payload|
+          guild = Discord::Guild.new(payload)
+          cache(guild)
+        end
+
+        @client.on_guild_update do |payload|
+          cache(payload)
+        end
+
+        @client.on_guild_delete do |payload|
+          remove(payload.id)
+        end
       end
     end
 
-    # Resolves the current user's profile. Requires no parameters since the
-    # endpoint has none either. If there is a gateway connection this should
-    # always be cached.
-    def resolve_current_user : User
-      @current_user ||= @client.get_current_user
-    end
+    module GuildMember
+      def init_handlers
+        @client.on_guild_member_add do |payload|
+          new_member = Discord::GuildMember.new(payload)
+          cache({payload.guild_id, new_member.user.id}, Discord::GuildMember.new(payload))
+        end
 
-    # Deletes a user from the cache given its *ID*.
-    def delete_user(id : UInt64)
-      @users.delete(id)
-    end
+        @client.on_guild_members_chunk do |payload|
+          payload.members.each do |member|
+            cache({payload.guild_id, member.id}, member)
+          end
+        end
 
-    # Deletes a channel from the cache given its *ID*.
-    def delete_channel(id : UInt64)
-      @channels.delete(id)
-    end
+        @client.on_guild_member_update do |payload|
+          if existing_member = resolve?({payload.guild_id, payload.user.id})
+            new_member = Discord::GuildMember.new(existing_member, payload.roles)
+            cache({payload.guild_id, new_member.user.id}, new_member)
+          else
+            new_member = Discord::GuildMember.new(payload)
+            cache({payload.guild_id, new_member.user.id}, Discord::GuildMember.new(payload))
+          end
+        end
 
-    # Deletes a guild from the cache given its *ID*.
-    def delete_guild(id : UInt64)
-      @guilds.delete(id)
-    end
+        @client.on_guild_member_remove do |payload|
+          remove({payload.guild_id, payload.user.id})
+        end
 
-    # Deletes a member from the cache given its *user_id* and the *guild_id* it
-    # is on.
-    def delete_member(guild_id : UInt64, user_id : UInt64)
-      @members[guild_id]?.try &.delete(user_id)
-    end
-
-    # Deletes a role from the cache given its *ID*.
-    def delete_role(id : UInt64)
-      @roles.delete(id)
-    end
-
-    # Deletes a DM channel with a particular user given the *recipient_id*.
-    def delete_dm_channel(recipient_id : UInt64)
-      @dm_channels.delete(recipient_id)
-    end
-
-    # Deletes the current user from the cache, if that will ever be necessary.
-    def delete_current_user
-      @current_user = nil
-    end
-
-    # Adds a specific *user* to the cache.
-    def cache(user : User)
-      @users[user.id] = user
-    end
-
-    # Adds a specific *channel* to the cache.
-    def cache(channel : Channel)
-      @channels[channel.id] = channel
-    end
-
-    # Adds a specific *guild* to the cache.
-    def cache(guild : Guild)
-      @guilds[guild.id] = guild
-    end
-
-    # Adds a specific *member* to the cache, given the *guild_id* it is on.
-    def cache(member : GuildMember, guild_id : UInt64)
-      local_members = @members[guild_id] ||= Hash(UInt64, GuildMember).new
-      local_members[member.user.id] = member
-    end
-
-    # Adds a specific *role* to the cache.
-    def cache(role : Role)
-      @roles[role.id] = role
-    end
-
-    # Adds a particular DM channel to the cache, given the *channel_id* and the
-    # *recipient_id*.
-    def cache_dm_channel(channel_id : UInt64, recipient_id : UInt64)
-      @dm_channels[recipient_id] = channel_id
-    end
-
-    # Caches the current user.
-    def cache_current_user(@current_user : User); end
-
-    # Adds multiple *members* at once to the cache, given the *guild_id* they
-    # all share. This method exists to slightly reduce the overhead of
-    # processing chunks; outside of that it is likely not of much use.
-    def cache_multiple_members(members : Array(GuildMember), guild_id : UInt64)
-      local_members = @members[guild_id] ||= Hash(UInt64, GuildMember).new
-      members.each do |member|
-        local_members[member.user.id] = member
+        @client.on_guild_create do |payload|
+          payload.members.each do |member|
+            cache({payload.id, member.user.id}, member)
+          end
+        end
       end
     end
 
-    # Returns all roles of a guild, identified by its *guild_id*.
-    def guild_roles(guild_id : UInt64) : Array(UInt64)
-      @guild_roles[guild_id]
+    # Handlers for `Role`-related gateway events
+    module Role
+      def init_handlers
+        @client.on_guild_create do |payload|
+          payload.roles.each { |role| cache({payload.id, role.id}, role) }
+        end
+
+        @client.on_guild_role_create do |payload|
+          cache({payload.guild_id, payload.role.id}, payload.role)
+        end
+
+        @client.on_guild_role_update do |payload|
+          cache({payload.guild_id, payload.role.id}, payload.role)
+        end
+
+        @client.on_guild_role_delete do |payload|
+          remove({payload.guild_id, payload.role_id})
+        end
+      end
     end
 
-    # Marks a role, identified by the *role_id*, as belonging to a particular
-    # guild, identified by the *guild_id*.
-    def add_guild_role(guild_id : UInt64, role_id : UInt64)
-      local_roles = @guild_roles[guild_id] ||= [] of UInt64
-      local_roles << role_id
+    # Handlers for `Channel`-related gateway events.
+    module Channel
+      def init_handlers
+        @client.on_guild_create do |payload|
+          payload.channels.each { |channel| cache(channel) }
+        end
+
+        @client.on_channel_create do |payload|
+          cache(payload)
+        end
+
+        @client.on_channel_update do |payload|
+          cache(payload)
+        end
+
+        @client.on_channel_delete do |payload|
+          remove(payload.id)
+        end
+      end
     end
 
-    # Marks a role as not belonging to a particular guild anymore.
-    def remove_guild_role(guild_id : UInt64, role_id : UInt64)
-      @guild_roles[guild_id]?.try { |local_roles| local_roles.delete(role_id) }
-    end
+    # Handlers for `Message`-related gateway events.
+    module Message
+      def init_handlers
+        @client.on_message_create do |payload|
+          cache(payload)
+        end
 
-    # Returns all channels of a guild, identified by its *guild_id*.
-    def guild_channels(guild_id : UInt64) : Array(UInt64)
-      @guild_channels[guild_id]
-    end
+        @client.on_message_update do |payload|
+          cache(payload)
+        end
 
-    # Marks a channel, identified by the *channel_id*, as belonging to a particular
-    # guild, identified by the *guild_id*.
-    def add_guild_channel(guild_id : UInt64, channel_id : UInt64)
-      local_channels = @guild_channels[guild_id] ||= [] of UInt64
-      local_channels << channel_id
-    end
-
-    # Marks a channel as not belonging to a particular guild anymore.
-    def remove_guild_channel(guild_id : UInt64, channel_id : UInt64)
-      @guild_channels[guild_id]?.try { |local_channels| local_channels.delete(channel_id) }
+        @client.on_message_delete do |payload|
+          remove(payload)
+        end
+      end
     end
   end
 end
+
+require "./cache/*"

--- a/src/discordcr/cache/guild.cr
+++ b/src/discordcr/cache/guild.cr
@@ -1,0 +1,93 @@
+module Discord::Cache
+  module Memory
+    class Guild
+      # Store guilds by their snowflake ID
+      include TypeCache(UInt64, Discord::Guild)
+
+      # Include the template set of event handlers for guild-related events
+      include Handlers::Guild
+
+      @guilds = {} of UInt64 => Discord::Guild
+
+      def cache(id : UInt64, guild : Discord::Guild)
+        Discord::LOGGER.info("Caching guild: #{id} (#{@guilds.size})")
+        @guilds[id] = guild
+      end
+
+      def resolve?(id : UInt64)
+        Discord::LOGGER.info("Resolving guild: #{id} (#{@guilds.size})")
+        @guilds[id]?
+      end
+
+      def remove(id : UInt64)
+        Discord::LOGGER.info("Removing guild: #{id} (#{@guilds.size})")
+        @guilds.delete(id)
+      end
+    end
+
+    class GuildMember
+      # Store guilds by their snowflake ID
+      include TypeCache({UInt64, UInt64}, Discord::GuildMember)
+
+      # Include the template set of event handlers for guild-related events
+      include Handlers::GuildMember
+
+      @guild_members = {} of {UInt64, UInt64} => Discord::GuildMember
+      @guild_members_map = Hash(UInt64, Set(UInt64)).new(Set(UInt64).new)
+
+      def cache(id : {UInt64, UInt64}, member : Discord::GuildMember)
+        Discord::LOGGER.info("Caching guild_member: #{id} (#{@guild_members.size})")
+        @guild_members_map[id[0]].add(id[1])
+        @guild_members[id] = member
+      end
+
+      def resolve?(id : {UInt64, UInt64})
+        Discord::LOGGER.info("Resolving guild_member: #{id}")
+        @guild_members[id]?
+      end
+
+      def resolve(guild_id : UInt64)
+        @guild_members_map[guild_id].map { |id| resolve?({guild_id, id}) }
+      end
+
+      def remove(id : {UInt64, UInt64})
+        Discord::LOGGER.info("Removing guild_member: #{id}")
+        @guild_members_map[id[0]].delete(id[1])
+        @guild_members.delete(id)
+      end
+    end
+
+    class Role
+      # Store guilds by their snowflake ID
+      include TypeCache({UInt64, UInt64}, Discord::Role)
+
+      # Include the template set of event handlers for guild-related events
+      include Handlers::Role
+
+      @roles = {} of {UInt64, UInt64} => Discord::Role
+      @guild_role_map = Hash(UInt64, Set(UInt64)).new(Set(UInt64).new)
+
+      def cache(id : {UInt64, UInt64}, role : Discord::Role)
+        Discord::LOGGER.info("Caching role: #{id} (#{@roles.size})")
+        @guild_role_map[id[0]].add(id[1])
+        @roles[id] = role
+      end
+
+      def resolve?(id : {UInt64, UInt64})
+        Discord::LOGGER.info("Resolving role: #{id}")
+        @roles[id]?
+      end
+
+      def resolve(guild_id : UInt64)
+        Discord::LOGGER.info("Resolving roles for guild: #{guild_id}")
+        @guild_role_map[guild_id].map { |id| resolve?({guild_id, id}) }
+      end
+
+      def remove(id : {UInt64, UInt64})
+        Discord::LOGGER.info("Removing role: #{id}")
+        @guild_role_map[id[0]].delete(id[1])
+        @roles.delete(id)
+      end
+    end
+  end
+end

--- a/src/discordcr/cached_client.cr
+++ b/src/discordcr/cached_client.cr
@@ -1,0 +1,67 @@
+require "./client"
+
+module Discord
+  # `CachedClient` is an extension of `Client` that adds customizable caches to track state.
+  class CachedClient < Client
+    getter! cache_set : Cache::CacheSet
+
+    def initialize(token : String, client_id : UInt64,
+                   shard : Gateway::ShardKey? = nil,
+                   large_threshold : Int32 = 100,
+                   compress : Bool = false,
+                   properties : Gateway::IdentifyProperties = DEFAULT_PROPERTIES)
+      super(token, client_id, shard, large_threshold, compress, properties)
+      @cache_set = Cache::CacheSet.new(self)
+    end
+
+    macro cached_route(method, key_type, resource_type)
+      {% if key_type.is_a?(TupleLiteral) %}
+        {{index = 0}}
+        {{typed_args = key_type.map { |key| index = index + 1; "arg#{index} : #{key}" }}}
+
+        {{index = 0}}
+        {{args = key_type.map { |key| index = index + 1; "arg#{index}" }}}
+        # See `REST#{{method}}`
+        def {{method}}({{typed_args.map(&.id).splat}})
+          if cache = cache_set[{{resource_type}}]
+            object = cache.resolve?({{args.map(&.id)}})
+            object ||= cache.cache(
+              {{args.map(&.id)}},
+              super({{args.map(&.id).splat}})
+            )
+          else
+            super({{args.map(&.id).splat}})
+          end
+        end
+      {% else %}
+        # See `REST#{{method}}`
+        def {{method}}(id : {{key_type}})
+          if cache = cache_set[{{resource_type}}]
+            object = cache.resolve?(id)
+            object ||= cache.cache super(id)
+          else
+            super(id)
+          end
+        end
+      {% end %}
+    end
+
+    cached_route get_guild, UInt64, Guild
+
+    cached_route get_guild_member, {UInt64, UInt64}, GuildMember
+
+    cached_route get_guild_channel, UInt64, Channel
+
+    # See `REST#get_guild_roles`
+    def get_guild_roles(id : UInt64)
+      if cache = cache_set.role
+        roles = cache.resolve(id)
+        return roles unless roles.empty?
+        new_roles = super(id)
+        new_roles.map { |role| cache.cache({id, role.id}, role) }
+      else
+        super(id)
+      end
+    end
+  end
+end

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -21,7 +21,7 @@ module Discord
 
     # If this is set to any `Cache`, the data in the cache will be updated as
     # the client receives the corresponding gateway dispatches.
-    property cache : Cache?
+    property cache : Nil = nil
 
     # The internal *session* the client is currently using, necessary to create
     # a voice client, for example

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -248,6 +248,7 @@ module Discord
     struct GuildMemberUpdatePayload
       JSON.mapping(
         user: User,
+        nick: String?,
         roles: {type: Array(UInt64), converter: SnowflakeArrayConverter},
         guild_id: {type: UInt64, converter: SnowflakeConverter}
       )

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -76,6 +76,13 @@ module Discord
       # Presence updates have no joined_at or deaf/mute, thanks Discord
     end
 
+    # :nodoc:
+    def initialize(payload : Gateway::GuildMemberUpdatePayload)
+      @user = payload.user
+      @nick = payload.nick
+      @roles = payload.roles
+    end
+
     JSON.mapping(
       user: User,
       nick: {type: String, nilable: true},
@@ -84,6 +91,8 @@ module Discord
       deaf: {type: Bool, nilable: true},
       mute: {type: Bool, nilable: true}
     )
+
+    delegate id, to: user
   end
 
   struct Integration


### PR DESCRIPTION
# :warning: **WIP** :warning: 

Alright, I think this is at a point where I've kind of implemented all the concepts I wanted to capture with this cache to open a PR for any other early feedback.

## Current `Cache` Observations, Motivation

- Stores everything it can, cannot be customized without re-implementing or monkey patching
- Is always internal and in-memory
- Caching behavior is intertwined with gateway code
- Closes #31 
- Closes #32 

## Redesign

- Describes a common caching interface for a Discord type, `TypeCache`
- Users can write their own implementation of `TypeCache` and describe how they want the client to operate on them by defining `init_handlers`. For common Discord types, template collections of event handlers are provided for convenience which users can `include` on their own `TypeCache`, and extend by overriding `init_handlers` and calling `super`
- Introduces `CachedClient` which any `TypeCache` you like can be attached to. Inherits & overrides `Client`'s `REST` methods to cache `REST` results. Caches are managed by `CacheSet` which maps Discord types to their expected `TypeCache` generic.
- Provides a stock set of caches that implement `Hash` storage

The objective is to give users the tools necessary to implement whatever caching backend they like, with a minimal but extendable interface and behavior, chuck it inside `CachedClient`, and it should Just Work:tm:

### Usage

This currently compiles:
```cr
client = Discord::CachedClient.new(token: "token")

# Attach some Memory caches to `Guild` and `GuildMember` related events and REST calls
client.cache_set.configure(
  guild: Discord::Cache::Memory::Guild,
  guild_member: Discord::Cache::Memory::GuildMember
)

# Make cached calls
client.get_guild(225375815087554563_u64)

client.run
```

## Todo

- [ ] Implement the remaining `Handlers` and `Memory` caches
- [ ] Implement the remaining cache-able resources (`REST` and gateway delegations) into `CachedClient`
- [x] Implement some sort of relationship caching (ex: Guild ID -> Channel ID)? Redis is a personal implementation target (as a seperate shard) and sets would be a good use for this, but I'm not entirely sure about other implementations. I could use `Set`, but this would not work with `TypeCache` as is.
- [ ] Decide if iterators like `#each` should be expected from `TypeCache` or users should just implement that on their own. Perhaps only on the `Memory` caches
- [ ] A shortcut for spinning up `CachedClient` with all `Memory` caches (constant tuple or something)
- [ ] Separate logger for caching? Remove or lower debugging logging level either way. Probably log more things too (handler calls?)
- [ ] More docs in places could be used, I'm sure
- [ ] Format
- [ ] Testing
- [ ] Tidy commit history

### Other thoughts

- The current macros work (perhaps they won't as I add more cache types) but I'm sure they could be tidied in some way that I couldn't figure out yet. Feedback especially welcome here.