### PR TITLE
Add helper method for encoding tuples to JSON, omitting pairs with null values

### DIFF
--- a/spec/rest_spec.cr
+++ b/spec/rest_spec.cr
@@ -1,0 +1,10 @@
+require "./spec_helper"
+
+describe Discord::REST do
+  describe "#encode_tuple" do
+    it "doesn't emit null values" do
+      client = Discord::Client.new("foo", 0_u64)
+      client.encode_tuple(foo: ["bar", 1, 2], baz: nil).should eq(%({"foo":["bar",1,2]}))
+    end
+  end
+end

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -96,6 +96,18 @@ module Discord
       response
     end
 
+    # :nodoc:
+    def encode_tuple(**tuple)
+      JSON.build do |builder|
+        builder.object do
+          tuple.each do |key, value|
+            next if value.nil?
+            builder.field(key) { value.to_json(builder) }
+          end
+        end
+      end
+    end
+
     # Gets the gateway URL to connect to.
     #
     # [API docs for this method](https://discordapp.com/developers/docs/topics/gateway#get-gateway)
@@ -148,15 +160,16 @@ module Discord
     # permission.
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/channel#modify-channel)
-    def modify_channel(channel_id : UInt64, name : String?, position : UInt32?,
-                       topic : String?, bitrate : UInt32?, user_limit : UInt32?)
-      json = {
-        name:       name,
-        position:   position,
-        topic:      topic,
-        bitrate:    bitrate,
-        user_limit: user_limit,
-      }.to_json
+    def modify_channel(channel_id : UInt64, name : String? = nil, position : UInt32? = nil,
+                       topic : String? = nil, bitrate : UInt32? = nil, user_limit : UInt32? = nil,
+                       nsfw : Bool? = nil)
+      json = encode_tuple(
+        name: name,
+        position: position,
+        topic: topic,
+        bitrate: bitrate,
+        user_limit: user_limit
+      )
 
       response = request(
         :channels_cid,
@@ -174,7 +187,7 @@ module Discord
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/channel#deleteclose-channel)
     def delete_channel(channel_id : UInt64)
-      response = request(
+      request(
         :channels_cid,
         channel_id,
         "DELETE",
@@ -288,7 +301,7 @@ module Discord
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/channel#delete-own-reaction)
     def delete_own_reaction(channel_id : UInt64, message_id : UInt64, emoji : String)
-      response = request(
+      request(
         :channels_cid_messages_mid_reactions_emoji_me,
         channel_id,
         "DELETE",
@@ -305,7 +318,7 @@ module Discord
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/channel#delete-user-reaction)
     def delete_user_reaction(channel_id : UInt64, message_id : UInt64, emoji : String, user_id : UInt64)
-      response = request(
+      request(
         :channels_cid_messages_mid_reactions_emoji_uid,
         channel_id,
         "DELETE",
@@ -336,7 +349,7 @@ module Discord
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/channel#delete-all-reactions)
     def delete_all_reactions(channel_id : UInt64, message_id : UInt64)
-      response = request(
+      request(
         :channels_cid_messages_mid_reactions,
         channel_id,
         "DELETE",
@@ -439,11 +452,11 @@ module Discord
     # [API docs for this method](https://discordapp.com/developers/docs/resources/channel#edit-channel-permissions)
     def edit_channel_permissions(channel_id : UInt64, overwrite_id : UInt64,
                                  type : String, allow : Permissions, deny : Permissions)
-      json = {
+      json = encode_tuple(
         allow: allow,
-        deny:  deny,
-        type:  type,
-      }.to_json
+        deny: deny,
+        type: type
+      )
 
       response = request(
         :channels_cid_permissions_oid,
@@ -478,11 +491,11 @@ module Discord
     # [API docs for this method](https://discordapp.com/developers/docs/resources/channel#create-channel-invite)
     def create_channel_invite(channel_id : UInt64, max_age : UInt32 = 0_u32,
                               max_uses : UInt32 = 0_u32, temporary : Bool = false)
-      json = {
-        max_age:   max_age,
-        max_uses:  max_uses,
-        temporary: temporary,
-      }.to_json
+      json = encode_tuple(
+        max_age: max_age,
+        max_uses: max_uses,
+        temporary: temporary
+      )
 
       response = request(
         :channels_cid_invites,
@@ -591,22 +604,23 @@ module Discord
 
     # Modifies an existing guild with new properties. Requires the "Manage
     # Server" permission.
+    # NOTE: To remove a guild's icon, you can send an empty string for the `icon` argument.
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#modify-guild)
-    def modify_guild(guild_id : UInt64, name : String?, region : String?,
-                     verification_level : UInt8?, afk_channel_id : UInt64?,
-                     afk_timeout : Int32?, icon : String?, owner_id : UInt64?,
-                     splash : String?)
-      json = {
-        name:               name,
-        region:             region,
+    def modify_guild(guild_id : UInt64, name : String? = nil, region : String? = nil,
+                     verification_level : UInt8? = nil, afk_channel_id : UInt64? = nil,
+                     afk_timeout : Int32? = nil, icon : String? = nil, owner_id : UInt64? = nil,
+                     splash : String? = nil)
+      json = encode_tuple(
+        name: name,
+        region: region,
         verification_level: verification_level,
-        afk_channel_id:     afk_channel_id,
-        afk_timeout:        afk_timeout,
-        icon:               icon,
-        owner_id:           owner_id,
-        splash:             splash,
-      }.to_json
+        afk_channel_id: afk_channel_id,
+        afk_timeout: afk_timeout,
+        icon: icon,
+        owner_id: owner_id,
+        splash: splash
+      )
 
       response = request(
         :guilds_gid,
@@ -672,10 +686,10 @@ module Discord
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/emoji#create-guild-emoji)
     def create_guild_emoji(guild_id : UInt64, name : String, image : String)
-      json = {
-        name:  name,
+      json = encode_tuple(
+        name: name,
         image: image,
-      }.to_json
+      )
 
       response = request(
         :guild_gid_emojis,
@@ -711,12 +725,12 @@ module Discord
     # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#create-guild-channel)
     def create_guild_channel(guild_id : UInt64, name : String, type : UInt8,
                              bitrate : UInt32?, user_limit : UInt32?)
-      json = {
-        name:       name,
-        type:       type,
-        bitrate:    bitrate,
-        user_limit: user_limit,
-      }.to_json
+      json = encode_tuple(
+        name: name,
+        type: type,
+        bitrate: bitrate,
+        user_limit: user_limit
+      )
 
       response = request(
         :guilds_gid_channels,
@@ -751,7 +765,7 @@ module Discord
     #
     # There are no API docs for this method.
     def modify_guild_vanity_url(guild_id : UInt64, code : String)
-      response = request(
+      request(
         :guilds_gid_vanityurl,
         guild_id,
         "PATCH",
@@ -767,10 +781,10 @@ module Discord
     # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#modify-guild-channel)
     def modify_guild_channel(guild_id : UInt64, channel_id : UInt64,
                              position : UInt64)
-      json = {
-        id:       channel_id,
-        position: position,
-      }.to_json
+      json = encode_tuple(
+        id: channel_id,
+        position: position
+      )
 
       response = request(
         :guilds_gid_channels,
@@ -830,19 +844,21 @@ module Discord
     #  - and the "Move Members" permission as well as the "Connect" permission
     #    to the new channel when changing voice channel ID.
     #
+    # NOTE: To remove a member's nickname, you can send an empty string for the `nick` argument.
+    #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#modify-guild-member)
-    def modify_guild_member(guild_id : UInt64, user_id : UInt64, nick : String?,
-                            roles : Array(UInt64)?, mute : Bool?, deaf : Bool?,
-                            channel_id : UInt64?)
-      json = {
-        nick:       nick,
-        roles:      roles,
-        mute:       mute,
-        deaf:       deaf,
-        channel_id: channel_id,
-      }.to_json
+    def modify_guild_member(guild_id : UInt64, user_id : UInt64, nick : String? = nil,
+                            roles : Array(UInt64)? = nil, mute : Bool? = nil, deaf : Bool? = nil,
+                            channel_id : UInt64? = nil)
+      json = encode_tuple(
+        nick: nick,
+        roles: roles,
+        mute: mute,
+        deaf: deaf,
+        channel_id: channel_id
+      )
 
-      response = request(
+      request(
         :guilds_gid_members_uid,
         guild_id,
         "PATCH",
@@ -856,7 +872,7 @@ module Discord
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#remove-guild-member)
     def remove_guild_member(guild_id : UInt64, user_id : UInt64)
-      response = request(
+      request(
         :guilds_gid_members_uid,
         guild_id,
         "DELETE",
@@ -887,7 +903,7 @@ module Discord
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#create-guild-ban)
     def create_guild_ban(guild_id : UInt64, user_id : UInt64)
-      response = request(
+      request(
         :guilds_gid_bans_uid,
         guild_id,
         "PUT",
@@ -901,7 +917,7 @@ module Discord
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#remove-guild-ban)
     def remove_guild_ban(guild_id : UInt64, user_id : UInt64)
-      response = request(
+      request(
         :guilds_gid_bans_uid,
         guild_id,
         "DELETE",
@@ -933,13 +949,13 @@ module Discord
     def create_guild_role(guild_id : UInt64, name : String? = nil,
                           permissions : Permissions? = nil, colour : UInt32 = 0_u32,
                           hoist : Bool = false, mentionable : Bool = false)
-      json = {
-        name:        name,
+      json = encode_tuple(
+        name: name,
         permissions: permissions,
-        color:       colour,
-        hoist:       hoist,
-        mentionable: mentionable,
-      }.to_json
+        color: colour,
+        hoist: hoist,
+        mentionable: mentionable
+      )
 
       response = request(
         :get_guild_roles,
@@ -957,16 +973,16 @@ module Discord
     # well as the role to be lower than the bot's highest role.
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#modify-guild-role)
-    def modify_guild_role(guild_id : UInt64, role_id : UInt64, name : String?,
-                          permissions : Permissions, colour : UInt32?,
-                          position : Int32?, hoist : Bool?)
-      json = {
-        name:        name,
+    def modify_guild_role(guild_id : UInt64, role_id : UInt64, name : String? = nil,
+                          permissions : Permissions? = nil, colour : UInt32? = nil,
+                          position : Int32? = nil, hoist : Bool? = nil)
+      json = encode_tuple(
+        name: name,
         permissions: permissions,
-        color:       colour,
-        position:    position,
-        hoist:       hoist,
-      }.to_json
+        color: colour,
+        position: position,
+        hoist: hoist
+      )
 
       response = request(
         :guilds_gid_roles_rid,
@@ -1070,12 +1086,12 @@ module Discord
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#create-guild-integration)
     def create_guild_integration(guild_id : UInt64, type : String, id : UInt64)
-      json = {
+      json = encode_tuple(
         type: type,
-        id:   id,
-      }.to_json
+        id: id
+      )
 
-      response = request(
+      request(
         :guilds_gid_integrations,
         guild_id,
         "POST",
@@ -1093,13 +1109,13 @@ module Discord
                                  expire_behaviour : UInt8,
                                  expire_grace_period : Int32,
                                  enable_emoticons : Bool)
-      json = {
-        expire_behavior:     expire_behaviour,
+      json = encode_tuple(
+        expire_behavior: expire_behaviour,
         expire_grace_period: expire_grace_period,
-        enable_emoticons:    enable_emoticons,
-      }.to_json
+        enable_emoticons: enable_emoticons
+      )
 
-      response = request(
+      request(
         :guilds_gid_integrations_iid,
         guild_id,
         "PATCH",
@@ -1113,7 +1129,7 @@ module Discord
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#delete-guild-integration)
     def delete_guild_integration(guild_id : UInt64, integration_id : UInt64)
-      response = request(
+      request(
         :guilds_gid_integrations_iid,
         guild_id,
         "DELETE",
@@ -1127,7 +1143,7 @@ module Discord
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#sync-guild-integration)
     def sync_guild_integration(guild_id : UInt64, integration_id : UInt64)
-      response = request(
+      request(
         :guilds_gid_integrations_iid_sync,
         guild_id,
         "POST",
@@ -1158,10 +1174,10 @@ module Discord
     # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#modify-guild-embed)
     def modify_guild_embed(guild_id : UInt64, enabled : Bool,
                            channel_id : UInt64)
-      json = {
-        enabled:    enabled,
-        channel_id: channel_id,
-      }.to_json
+      json = encode_tuple(
+        enabled: enabled,
+        channel_id: channel_id
+      )
 
       response = request(
         :guilds_gid_embed,
@@ -1208,13 +1224,14 @@ module Discord
     end
 
     # Modifies the current bot user, changing the username and avatar.
+    # NOTE: To remove the current user's avatar, you can send an empty string for the `avatar` argument.
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/user#modify-current-user)
-    def modify_current_user(username : String, avatar : String)
-      json = {
+    def modify_current_user(username : String? = nil, avatar : String? = nil)
+      json = encode_tuple(
         username: username,
-        avatar:   avatar,
-      }.to_json
+        avatar: avatar
+      )
 
       response = request(
         :users_me,
@@ -1261,7 +1278,7 @@ module Discord
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/user#leave-guild)
     def leave_guild(guild_id : UInt64)
-      response = request(
+      request(
         :users_me_guilds_gid,
         nil,
         "DELETE",


### PR DESCRIPTION
This accomplishes the same (supersedes) as #80 , by making a single helper method that encodes tuples using `JSON.build` that skips null-valued keys for the same performance, as far as I can see.

While there's nothing wrong with additional structs in #80, if the *only* reason there are there is to control null-emission when building JSON, it is much less work to maintain the REST binding with this as you no longer have to maintain *both* the methods and the structs as API methods are added or fixed - you just call `encode_tuple` and don't have to think about anything else.

I originally wanted to make this a private method, as there's no real reason to expose it, but I'm not sure how I would spec the private method, as that doesn't compile.

This also does some small housekeeping of removing setting of temporary `response =` variables when they weren't being used at all in the rest of the method.

I originally wasn't going to open this, but I had it laying around, #80 still wasn't merged, and #HACKTOBER Y'ALL

ahem