### PR TITLE
Fix GuildBan payload

### DIFF
--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -209,11 +209,7 @@ module Discord
 
     struct GuildBanPayload
       JSON.mapping(
-        username: String,
-        id: {type: UInt64, converter: SnowflakeConverter},
-        discriminator: String,
-        avatar: String,
-        bot: Bool?,
+        user: User,
         guild_id: {type: UInt64, converter: SnowflakeConverter}
       )
     end

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -165,6 +165,13 @@ module Discord
     {% end %}
   end
 
+  struct GuildBan
+    JSON.mapping(
+      user: User,
+      reason: String?
+    )
+  end
+
   struct GamePlaying
     def initialize(@name = nil, @type = nil, @url = nil)
     end

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -896,7 +896,7 @@ module Discord
         nil
       )
 
-      Array(User).from_json(response.body)
+      Array(GuildBan).from_json(response.body)
     end
 
     # Bans a member from the guild. Requires the "Ban Members" permission.


### PR DESCRIPTION
A guild ban has two keys, `user` and `guild_id`.