### PR TITLE
Use TimestampConverter instead of DATE_FORMAT

### DIFF
--- a/spec/discordcr_spec.cr
+++ b/spec/discordcr_spec.cr
@@ -19,11 +19,33 @@ struct StructWithSnowflakeArray
   )
 end
 
+struct StructWithTime
+  JSON.mapping(
+    data: {type: Time, converter: Discord::TimestampConverter}
+  )
+end
+
 describe Discord do
   describe "VERSION" do
     it "matches shards.yml" do
       version = YAML.parse(File.read(File.join(__DIR__, "..", "shard.yml")))["version"].as_s
       version.should eq(Discord::VERSION)
+    end
+  end
+
+  describe Discord::TimestampConverter do
+    it "parses a time with floating point accuracy" do
+      json = %({"data":"2017-11-16T13:09:18.291000+00:00"})
+
+      obj = StructWithTime.from_json(json)
+      obj.data.should be_a Time
+    end
+
+    it "parses a time without floating point accuracy" do
+      json = %({"data":"2017-11-15T02:23:35+00:00"})
+
+      obj = StructWithTime.from_json(json)
+      obj.data.should be_a Time
     end
   end
 

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -8,7 +8,7 @@ module Discord
       id: {type: UInt64, converter: SnowflakeConverter},
       channel_id: {type: UInt64, converter: SnowflakeConverter},
       author: User,
-      timestamp: {type: Time, converter: DATE_FORMAT},
+      timestamp: {type: Time, converter: TimestampConverter},
       tts: Bool,
       mention_everyone: Bool,
       mentions: Array(User),

--- a/src/discordcr/mappings/converters.cr
+++ b/src/discordcr/mappings/converters.cr
@@ -2,7 +2,18 @@ require "json"
 require "time/format"
 
 module Discord
-  DATE_FORMAT = Time::Format.new("%FT%T.%L%:z")
+  # :nodoc:
+  module TimestampConverter
+    def self.from_json(parser : JSON::PullParser)
+      time_str = parser.read_string
+
+      begin
+        Time::Format.new("%FT%T.%L%:z", Time::Kind::Utc).parse(time_str)
+      rescue Time::Format::Error
+        Time::Format.new("%FT%T%:z", Time::Kind::Utc).parse(time_str)
+      end
+    end
+  end
 
   # :nodoc:
   module EmbedTimestampConverter

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -242,7 +242,7 @@ module Discord
         user: User,
         nick: String?,
         roles: {type: Array(UInt64), converter: SnowflakeArrayConverter},
-        joined_at: {type: Time?, converter: DATE_FORMAT},
+        joined_at: {type: Time?, converter: TimestampConverter},
         deaf: Bool,
         mute: Bool,
         guild_id: {type: UInt64, converter: SnowflakeConverter}
@@ -309,7 +309,7 @@ module Discord
         id: {type: UInt64, converter: SnowflakeConverter},
         channel_id: {type: UInt64, converter: SnowflakeConverter},
         author: User?,
-        timestamp: {type: Time?, converter: DATE_FORMAT},
+        timestamp: {type: Time?, converter: TimestampConverter},
         tts: Bool?,
         mention_everyone: Bool?,
         mentions: Array(User)?,


### PR DESCRIPTION
Discord sometimes sends timestamps without floating point accuracy, which is still a valid ISO 8601 timestamp. This would throw an exception and fail to parse the message.