### PR TITLE
Fix deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -12,7 +12,7 @@ function doCompile {
 }
 
 # Pull requests and commits to other branches shouldn't try to deploy, just build to verify
-if [ "$TRAVIS_PULL_REQUEST" != "false" -o ["$TRAVIS_BRANCH" != "$SOURCE_BRANCH" && -z "$TRAVIS_TAG" ] ]; then
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] || { [ "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ] && [ -z "$TRAVIS_TAG" ]; }; then
     echo "Skipping deploy; just doing a build."
     doCompile
     exit 0
@@ -51,7 +51,7 @@ git config user.name "Travis CI"
 git config user.email "$COMMIT_AUTHOR_EMAIL"
 
 # If there are no changes to the compiled out (e.g. this is a README update) then just bail.
-$DIFF_RESULT = `git diff --exit-code`
+DIFF_RESULT=`git diff --exit-code`
 if [ -z "$DIFF_RESULT" ]; then
     echo "No changes to the output on this push; exiting."
     exit 0


### PR DESCRIPTION
Seems there were some issues with the `deploy.sh` script.
See this [Travis CI build](https://travis-ci.org/meew0/discordcr/builds/303046746#L517-L530) for more info.

Script has been updated and tested by @z64 on [his fork](https://github.com/z64/discordcr/pull/1)