### PR TITLE
Fix REST#modify_guild_channel_positions

### DIFF
--- a/spec/discordcr_spec.cr
+++ b/spec/discordcr_spec.cr
@@ -65,4 +65,22 @@ describe Discord do
       obj.data[2].should eq 10000000000
     end
   end
+
+  describe Discord::REST::ModifyChannelPositionPayload do
+    describe "#to_json" do
+      context "parent_id is MaybeField::Unchanged" do
+        it "doesn't emit parent_id" do
+          payload = {Discord::REST::ModifyChannelPositionPayload.new(0_u64, 0, Discord::REST::MaybeField::Unchanged, true)}
+          payload.to_json.should eq %([{"id":"0","position":0,"lock_permissions":true}])
+        end
+      end
+
+      context "parent_id is MaybeField::None" do
+        it "emits null for parent_id" do
+          payload = {Discord::REST::ModifyChannelPositionPayload.new(0_u64, 0, Discord::REST::MaybeField::None, true)}
+          payload.to_json.should eq %([{"id":"0","position":0,"parent_id":null,"lock_permissions":true}])
+        end
+      end
+    end
+  end
 end

--- a/spec/discordcr_spec.cr
+++ b/spec/discordcr_spec.cr
@@ -68,16 +68,16 @@ describe Discord do
 
   describe Discord::REST::ModifyChannelPositionPayload do
     describe "#to_json" do
-      context "parent_id is MaybeField::Unchanged" do
+      context "parent_id is ChannelParent::Unchanged" do
         it "doesn't emit parent_id" do
-          payload = {Discord::REST::ModifyChannelPositionPayload.new(0_u64, 0, Discord::REST::MaybeField::Unchanged, true)}
+          payload = {Discord::REST::ModifyChannelPositionPayload.new(0_u64, 0, Discord::REST::ChannelParent::Unchanged, true)}
           payload.to_json.should eq %([{"id":"0","position":0,"lock_permissions":true}])
         end
       end
 
-      context "parent_id is MaybeField::None" do
+      context "parent_id is ChannelParent::None" do
         it "emits null for parent_id" do
-          payload = {Discord::REST::ModifyChannelPositionPayload.new(0_u64, 0, Discord::REST::MaybeField::None, true)}
+          payload = {Discord::REST::ModifyChannelPositionPayload.new(0_u64, 0, Discord::REST::ChannelParent::None, true)}
           payload.to_json.should eq %([{"id":"0","position":0,"parent_id":null,"lock_permissions":true}])
         end
       end

--- a/src/discordcr/mappings/enums.cr
+++ b/src/discordcr/mappings/enums.cr
@@ -1,0 +1,8 @@
+module Discord::REST
+  # Enum for `parent_id` null significance in
+  # `REST#modify_guild_channel_positions`.
+  enum ChannelParent
+    None
+    Unchanged
+  end
+end

--- a/src/discordcr/mappings/rest.cr
+++ b/src/discordcr/mappings/rest.cr
@@ -2,6 +2,13 @@ require "./converters"
 
 module Discord
   module REST
+    # Enum for controlling emission of JSON key/value pairs where
+    # JSON `null` is a significant value.
+    enum MaybeField
+      None
+      Unchanged
+    end
+
     # A response to the Get Gateway REST API call.
     struct GatewayResponse
       JSON.mapping(
@@ -25,14 +32,33 @@ module Discord
 
     # A request payload to rearrange channels in a `Guild` by a REST API call.
     struct ModifyChannelPositionPayload
-      JSON.mapping(
-        id: {type: UInt64, converter: SnowflakeConverter},
-        position: Int32,
-        parent_id: {type: UInt64?, converter: MaybeSnowflakeConverter},
-        lock_permissions: Bool?
-      )
+      def initialize(@id : UInt64, @position : Int32,
+                     @parent_id : UInt64 | MaybeField = MaybeField::Unchanged,
+                     @lock_permissions : Bool? = nil)
+      end
 
-      def initialize(@id, @position, @parent_id = nil, @lock_permissions = nil)
+      def to_json(builder : JSON::Builder)
+        builder.object do
+          builder.field("id") do
+            SnowflakeConverter.to_json(@id, builder)
+          end
+
+          builder.field("position", @position)
+
+          parent = @parent_id
+
+          if parent.is_a?(MaybeField)
+            if parent.none?
+              builder.field("parent_id", nil)
+            end
+          else
+            builder.field("parent_id") do
+              SnowflakeConverter.to_json(parent, builder)
+            end
+          end
+
+          builder.field("lock_permissions", @lock_permissions) unless @lock_permissions.nil?
+        end
       end
     end
   end

--- a/src/discordcr/mappings/rest.cr
+++ b/src/discordcr/mappings/rest.cr
@@ -22,5 +22,18 @@ module Discord
         code: String
       )
     end
+
+    # A request payload to rearrange channels in a `Guild` by a REST API call.
+    struct ModifyChannelPositionPayload
+      JSON.mapping(
+        id: {type: UInt64, converter: SnowflakeConverter},
+        position: Int32,
+        parent_id: {type: UInt64?, converter: MaybeSnowflakeConverter},
+        lock_permissions: Bool?
+      )
+
+      def initialize(@id, @position, @parent_id = nil, @lock_permissions = nil)
+      end
+    end
   end
 end

--- a/src/discordcr/mappings/rest.cr
+++ b/src/discordcr/mappings/rest.cr
@@ -2,13 +2,6 @@ require "./converters"
 
 module Discord
   module REST
-    # Enum for controlling emission of JSON key/value pairs where
-    # JSON `null` is a significant value.
-    enum MaybeField
-      None
-      Unchanged
-    end
-
     # A response to the Get Gateway REST API call.
     struct GatewayResponse
       JSON.mapping(
@@ -33,7 +26,7 @@ module Discord
     # A request payload to rearrange channels in a `Guild` by a REST API call.
     struct ModifyChannelPositionPayload
       def initialize(@id : UInt64, @position : Int32,
-                     @parent_id : UInt64 | MaybeField = MaybeField::Unchanged,
+                     @parent_id : UInt64 | ChannelParent = ChannelParent::Unchanged,
                      @lock_permissions : Bool? = nil)
       end
 
@@ -48,9 +41,9 @@ module Discord
           case parent = @parent_id
           when UInt64
             SnowflakeConverter.to_json(parent, builder)
-          when MaybeField::None
+          when ChannelParent::None
             builder.field("parent_id", nil)
-          when MaybeField::Unchanged
+          when ChannelParent::Unchanged
             # no field
           end
 

--- a/src/discordcr/mappings/rest.cr
+++ b/src/discordcr/mappings/rest.cr
@@ -45,16 +45,13 @@ module Discord
 
           builder.field("position", @position)
 
-          parent = @parent_id
-
-          if parent.is_a?(MaybeField)
-            if parent.none?
-              builder.field("parent_id", nil)
-            end
-          else
-            builder.field("parent_id") do
-              SnowflakeConverter.to_json(parent, builder)
-            end
+          case parent = @parent_id
+          when UInt64
+            SnowflakeConverter.to_json(parent, builder)
+          when MaybeField::None
+            builder.field("parent_id", nil)
+          when MaybeField::Unchanged
+            # no field
           end
 
           builder.field("lock_permissions", @lock_permissions) unless @lock_permissions.nil?

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -761,27 +761,20 @@ module Discord
       )
     end
 
-    # Modifies a guild channel's position. Requires the "Manage Channels"
-    # permission.
+    # Modifies the position of channels within a guild. Requires the
+    # "Manage Channels" permission.
     #
-    # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#modify-guild-channel)
-    def modify_guild_channel(guild_id : UInt64, channel_id : UInt64,
-                             position : UInt64)
-      json = {
-        id:       channel_id,
-        position: position,
-      }.to_json
-
-      response = request(
+    # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#modify-guild-channel-positions)
+    def modify_guild_channel_positions(guild_id : UInt64,
+                                       positions : Array(ModifyChannelPositionPayload))
+      request(
         :guilds_gid_channels,
         guild_id,
         "PATCH",
         "/guilds/#{guild_id}/channels",
         HTTP::Headers{"Content-Type" => "application/json"},
-        json
+        positions.to_json
       )
-
-      Channel.from_json(response.body)
     end
 
     # Gets a specific member by both IDs.


### PR DESCRIPTION
This endpoint doesn't work as written. I've renamed it to match the intended endpoint, and added a struct to pass as an argument.

It may be helpful to add an abstraction that lets you move channels around in the most basic manner, as [it's kind of a pain](https://github.com/z64/discordrb/blob/8972d84b222bcdcd027e4f81e8dd9e71a0e57aaa/lib/discordrb/data.rb#L1374-L1434). Would this be acceptable? If so I'll do this in another PR. This one at least makes the endpoint usable.