### PR TITLE
Remove Channel#is_private?

### DIFF
--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -34,7 +34,6 @@ module Discord
       type: UInt8,
       guild_id: {type: UInt64?, converter: MaybeSnowflakeConverter},
       name: String?,
-      is_private: Bool?,
       permission_overwrites: Array(Overwrite)?,
       topic: String?,
       last_message_id: {type: UInt64?, converter: MaybeSnowflakeConverter},


### PR DESCRIPTION
[This field doesn't exist in API v6](https://discordapp.com/developers/docs/change-log#july-19-2017). DM channels are indicated by `type == 1` (DM) or `type == 3` (group DM).