### PR TITLE
Use enums for Message and Channel type

### DIFF
--- a/spec/discordcr_spec.cr
+++ b/spec/discordcr_spec.cr
@@ -31,6 +31,12 @@ struct StructWithMessageType
   )
 end
 
+struct StructWithChannelType
+  JSON.mapping(
+    data: {type: Discord::ChannelType, converter: Discord::ChannelTypeConverter}
+  )
+end
+
 describe Discord do
   describe "VERSION" do
     it "matches shards.yml" do
@@ -108,6 +114,25 @@ describe Discord do
 
         expect_raises(Exception, %(Unexpected message type value: "foo")) do
           StructWithMessageType.from_json(json)
+        end
+      end
+    end
+  end
+
+  describe Discord::ChannelTypeConverter do
+    it "converts an integer into a ChannelType" do
+      json = %({"data": 0})
+
+      obj = StructWithChannelType.from_json(json)
+      obj.data.should eq Discord::ChannelType::GuildText
+    end
+
+    context "with an invalid json value" do
+      it "raises" do
+        json = %({"data":"foo"})
+
+        expect_raises(Exception, %(Unexpected channel type value: "foo")) do
+          StructWithChannelType.from_json(json)
         end
       end
     end

--- a/spec/discordcr_spec.cr
+++ b/spec/discordcr_spec.cr
@@ -25,6 +25,12 @@ struct StructWithTime
   )
 end
 
+struct StructWithMessageType
+  JSON.mapping(
+    data: {type: Discord::MessageType, converter: Discord::MessageTypeConverter}
+  )
+end
+
 describe Discord do
   describe "VERSION" do
     it "matches shards.yml" do
@@ -85,6 +91,25 @@ describe Discord do
       obj.data[0].should eq 1
       obj.data[1].should eq 2
       obj.data[2].should eq 10000000000
+    end
+  end
+
+  describe Discord::MessageTypeConverter do
+    it "converts an integer into a MessageType" do
+      json = %({"data": 0})
+
+      obj = StructWithMessageType.from_json(json)
+      obj.data.should eq Discord::MessageType::Default
+    end
+
+    context "with an invalid json value" do
+      it "raises" do
+        json = %({"data":"foo"})
+
+        expect_raises(Exception, %(Unexpected message type value: "foo")) do
+          StructWithMessageType.from_json(json)
+        end
+      end
     end
   end
 end

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -1,9 +1,20 @@
 require "./converters"
 
 module Discord
+  enum MessageType : UInt8
+    Default              = 0
+    RecipientAdd         = 1
+    RecipientRemove      = 2
+    Call                 = 3
+    ChannelNameChange    = 4
+    ChannelIconChange    = 5
+    ChannelPinnedMessage = 6
+    GuildMemberJoin      = 7
+  end
+
   struct Message
     JSON.mapping(
-      type: UInt8?,
+      type: {type: MessageType, converter: MessageTypeConverter},
       content: String,
       id: {type: UInt64, converter: SnowflakeConverter},
       channel_id: {type: UInt64, converter: SnowflakeConverter},

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -80,6 +80,13 @@ module Discord
     Here
   end
 
+  enum ChannelType : UInt8
+    GuildText = 0
+    DM        = 1
+    Voice     = 2
+    GroupDM   = 3
+  end
+
   struct Channel
     # :nodoc:
     def initialize(private_channel : PrivateChannel)
@@ -91,7 +98,7 @@ module Discord
 
     JSON.mapping(
       id: {type: UInt64, converter: SnowflakeConverter},
-      type: UInt8,
+      type: {type: ChannelType, converter: ChannelTypeConverter},
       guild_id: {type: UInt64?, converter: MaybeSnowflakeConverter},
       name: String?,
       permission_overwrites: Array(Overwrite)?,
@@ -112,7 +119,7 @@ module Discord
   struct PrivateChannel
     JSON.mapping(
       id: {type: UInt64, converter: SnowflakeConverter},
-      type: UInt8,
+      type: {type: ChannelType, converter: ChannelTypeConverter},
       recipients: Array(User),
       last_message_id: {type: UInt64?, converter: MaybeSnowflakeConverter}
     )

--- a/src/discordcr/mappings/converters.cr
+++ b/src/discordcr/mappings/converters.cr
@@ -71,4 +71,19 @@ module Discord
       value.map(&.to_s).to_json(builder)
     end
   end
+
+  # :nodoc:
+  module MessageTypeConverter
+    def self.from_json(parser : JSON::PullParser)
+      if value = parser.read?(UInt8)
+        MessageType.new(value)
+      else
+        raise "Unexpected message type value: #{parser.read_raw}"
+      end
+    end
+
+    def self.to_json(value : MessageType, builder : JSON::Builder)
+      value.to_json(builder)
+    end
+  end
 end

--- a/src/discordcr/mappings/converters.cr
+++ b/src/discordcr/mappings/converters.cr
@@ -86,4 +86,15 @@ module Discord
       value.to_json(builder)
     end
   end
+
+  # :nodoc:
+  module ChannelTypeConverter
+    def self.from_json(parser : JSON::PullParser)
+      if value = parser.read?(UInt8)
+        ChannelType.new(value)
+      else
+        raise "Unexpected channel type value: #{parser.read_raw}"
+      end
+    end
+  end
 end

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -723,7 +723,7 @@ module Discord
     # permission.
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#create-guild-channel)
-    def create_guild_channel(guild_id : UInt64, name : String, type : UInt8,
+    def create_guild_channel(guild_id : UInt64, name : String, type : ChannelType,
                              bitrate : UInt32?, user_limit : UInt32?)
       json = encode_tuple(
         name: name,


### PR DESCRIPTION
Users should be able to work with these objects with the abstract enum values instead of having to look up a reference of what each integer value means.