### PR TITLE
Test converters directly, test serialization

### DIFF
--- a/spec/converters_spec.cr
+++ b/spec/converters_spec.cr
@@ -1,0 +1,29 @@
+require "./spec_helper"
+
+def it_converts(json, to value, with converter, file = __FILE__, line = __LINE__)
+  describe converter, file, line do
+    it "converts #{json} to #{value.class}" do
+      parser = JSON::PullParser.new(json)
+      converted = converter.from_json(parser)
+      converted.should eq value
+    end
+
+    it "serializes #{value} to JSON" do
+      converted = JSON.build do |builder|
+        converter.to_json(value, builder)
+      end
+
+      converted.should eq json
+    end
+  end
+end
+
+describe "Converters" do
+  it_converts(%("10000000000"), to: 10000000000_u64, with: Discord::SnowflakeConverter)
+  it_converts(%("10000000000"), to: 10000000000_u64, with: Discord::MaybeSnowflakeConverter)
+  it_converts("null", to: nil, with: Discord::MaybeSnowflakeConverter)
+  it_converts(%(["1","2","10000000000"]), to: [1_u64, 2_u64, 10000000000_u64], with: Discord::SnowflakeArrayConverter)
+
+  pending "Discord::EmbedTimestampConverter" do
+  end
+end

--- a/spec/discordcr_spec.cr
+++ b/spec/discordcr_spec.cr
@@ -1,24 +1,6 @@
 require "yaml"
 require "./spec_helper"
 
-struct StructWithSnowflake
-  JSON.mapping(
-    data: {type: UInt64, converter: Discord::SnowflakeConverter}
-  )
-end
-
-struct StructWithMaybeSnowflake
-  JSON.mapping(
-    data: {type: UInt64?, converter: Discord::MaybeSnowflakeConverter}
-  )
-end
-
-struct StructWithSnowflakeArray
-  JSON.mapping(
-    data: {type: Array(UInt64), converter: Discord::SnowflakeArrayConverter}
-  )
-end
-
 struct StructWithTime
   JSON.mapping(
     data: {type: Time, converter: Discord::TimestampConverter}
@@ -64,45 +46,6 @@ describe Discord do
       json = %({"data":"2017-11-16T13:09:18.291+00:00"})
       obj = StructWithTime.from_json(json)
       obj.to_json.should eq json
-    end
-  end
-
-  describe Discord::SnowflakeConverter do
-    it "converts a string to u64" do
-      json = %({"data":"10000000000"})
-
-      obj = StructWithSnowflake.from_json(json)
-      obj.data.should eq 10000000000
-      obj.data.should be_a UInt64
-    end
-  end
-
-  describe Discord::MaybeSnowflakeConverter do
-    it "converts a string to u64" do
-      json = %({"data":"10000000000"})
-
-      obj = StructWithMaybeSnowflake.from_json(json)
-      obj.data.should eq 10000000000
-      obj.data.should be_a UInt64
-    end
-
-    it "converts null to nil" do
-      json = %({"data":null})
-
-      obj = StructWithMaybeSnowflake.from_json(json)
-      obj.data.should eq nil
-    end
-  end
-
-  describe Discord::SnowflakeArrayConverter do
-    it "converts an array of strings to u64s" do
-      json = %({"data":["1", "2", "10000000000"]})
-
-      obj = StructWithSnowflakeArray.from_json(json)
-      obj.data.should be_a Array(UInt64)
-      obj.data[0].should eq 1
-      obj.data[1].should eq 2
-      obj.data[2].should eq 10000000000
     end
   end
 


### PR DESCRIPTION
The existing specs for converters weren't testing the converters directly. Additionally, we weren't testing serialization.

This refactor addresses this with a DRY spec helper that tests both parsing and serialization.