### PR TITLE
Define Packet#inspect to print data buffer

### DIFF
--- a/spec/discordcr_spec.cr
+++ b/spec/discordcr_spec.cr
@@ -87,4 +87,11 @@ describe Discord do
       obj.data[2].should eq 10000000000
     end
   end
+
+  describe Discord::WebSocket::Packet do
+    it "inspects" do
+      packet = Discord::WebSocket::Packet.new(0_i64, 1_i64, IO::Memory.new("foo"), "test")
+      packet.inspect.should eq %(Discord::WebSocket::Packet(@opcode=0_i64 @sequence=1_i64 @data="foo" @event_type="test"))
+    end
+  end
 end

--- a/src/discordcr/websocket.cr
+++ b/src/discordcr/websocket.cr
@@ -10,6 +10,18 @@ module Discord
 
       def initialize(@opcode : Int64?, @sequence : Int64?, @data : IO::Memory, @event_type : String?)
       end
+
+      def inspect(io : IO)
+        io << "Discord::WebSocket::Packet(@opcode="
+        opcode.inspect(io)
+        io << " @sequence="
+        sequence.inspect(io)
+        io << " @data="
+        data.to_s.inspect(io)
+        io << " @event_type="
+        event_type.inspect(io)
+        io << ')'
+      end
     end
 
     def initialize(@host : String, @path : String, @port : Int32, @tls : Bool)


### PR DESCRIPTION
When exceptions occur, namely those raised from errors such as JSON::ParseException, `#inspect` that is run in the exception logger prints a useless "IO::Memory" string making it difficult to debug the actual payload that is problematic without going back, adding logging, and trying to reproduce.

`master` implementation:
```
Discord::WebSocket::Packet(@opcode=0_i64, @sequence=90871_i64, @data=#<IO::Memory:0x55b76ff8dde0 @encoder=nil, @decoder=nil, @encoding=nil, @buffer=Pointer(UInt8)@0x55b76ff8c900, @bytesize=126, @capacity=128, @pos=126, @closed=false, @resizeable=true, @writeable=true>, @event_type="GUILD_BAN_ADD")
```
This PR prints the contents of the internal buffer instead:
```
Discord::WebSocket::Packet(@opcode=0_i64 @sequence=11_i64 @data="{\"user\":{\"username\":\"ccr\",\"id\":\"267934068035944459\",\"discriminator\":\"5458\",\"bot\":true,\"avatar\":\"b9c247884e5f19427206de121ac29085\"},\"guild_id\":\"225375815087554563\"}" @event_type="GUILD_BAN_REMOVE")
```
I'm not sure if this is the right way to implement `inspect`, and perhaps I should still state that its an `IO::Memory`, but I think this definitely has to be improved.