### PR TITLE
Fix webhook related endpoints

### DIFF
--- a/src/discordcr/mappings/rest.cr
+++ b/src/discordcr/mappings/rest.cr
@@ -22,40 +22,5 @@ module Discord
         code: String
       )
     end
-
-    # A request to the Modify Webhook REST API call.
-    class ModifyWebhookPayload
-      JSON.mapping(
-        name: String?,
-        avatar: String?,
-        channel_id: UInt64?
-      )
-
-      def initialize(@name, @avatar, @channel_id)
-      end
-    end
-
-    # A request to the Execute Webhook REST API call.
-    class ExecuteWebhookPayload
-      JSON.mapping(
-        content: String?,
-        file: String?,
-        embeds: Array(Embed)?,
-        tts: Bool?,
-        avatar_url: String?,
-        username: String?
-      )
-
-      def initialize(@content, @file, @embeds, @tts, @avatar_url, @username)
-      end
-    end
-
-    # A response to the Modify Webhook REST API call.
-    class ModifyWebhookPayload
-      JSON.mapping(name: String?, avatar: String?, channel_id: UInt64?)
-
-      def initialize(@name, @avatar, @channel_id)
-      end
-    end
   end
 end

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -1496,7 +1496,11 @@ module Discord
     # [API docs for this method](https://discordapp.com/developers/docs/resources/webhook#modify-webhook).
     def modify_webhook(webhook_id : UInt64, name : String? = nil, avatar : String? = nil,
                        channel_id : UInt64? = nil)
-      json = ModifyWebhookPayload.new(name, avatar, channel_id).to_json
+      json = encode_tuple(
+        name: name,
+        avatar: avatar,
+        channel_id: channel_id
+      )
 
       response = request(
         :webhooks_wid,
@@ -1514,14 +1518,17 @@ module Discord
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/webhook#modify-webhook-with-token).
     def modify_webhook_with_token(webhook_id : UInt64, token : String, name : String? = nil,
-                                  avatar : String? = nil, channel_id : UInt64? = nil)
-      json = ModifyWebhookPayload.new(name, avatar, channel_id).to_json
+                                  avatar : String? = nil)
+      json = encode_tuple(
+        name: name,
+        avatar: avatar
+      )
 
       response = request(
         :webhooks_wid,
         webhook_id,
         "PATCH",
-        "/webhooks/#{webhook_id}",
+        "/webhooks/#{webhook_id}/#{token}",
         HTTP::Headers{"Content-Type" => "application/json"},
         json
       )
@@ -1564,8 +1571,15 @@ module Discord
                         file : String? = nil, embeds : Array(Embed)? = nil,
                         tts : Bool? = nil, avatar_url : String? = nil,
                         username : String? = nil, wait : Bool? = false)
-      json = ExecuteWebhookPayload.new(content, file, embeds, tts,
-        avatar_url, username).to_json
+      json = encode_tuple(
+        content: content,
+        file: file,
+        embeds: embeds,
+        tts: tts,
+        avatar_url: avatar_url,
+        username: username
+      )
+
       response = request(
         :webhooks_wid,
         webhook_id,


### PR DESCRIPTION
- Use `encode_tuple` helper instead of structs (there was also two of the same exact struct..)
- Fix `modify_webhook_with_token` with wrong endpoint
- Fix `modify_webhook_with_token` accepting `channel_id` ("[..] does not accept a channel_id parameter in the body" from [docs](https://discordapp.com/developers/docs/resources/webhook#modify-webhook-with-token))