### PR TITLE
Add Mention.parse utility for parsing mentions

### DIFF
--- a/examples/mention_parser.cr
+++ b/examples/mention_parser.cr
@@ -1,0 +1,50 @@
+# This example demonstrates usage of `Discord::Mention.parse` to parse
+# and handle different kinds of mentions appearing in a message.
+
+require "../src/discordcr"
+
+# Make sure to replace this fake data with actual data when running.
+client = Discord::Client.new(token: "Bot MjI5NDU5NjgxOTU1NjUyMzM3.Cpnz31.GQ7K9xwZtvC40y8MPY3eTqjEIXm")
+
+client.on_message_create do |payload|
+  next unless payload.content.starts_with?("parse:")
+
+  mentions = String.build do |string|
+    index = 0
+    Discord::Mention.parse(payload.content) do |mention|
+      index += 1
+      string << "`[" << index << " @ " << mention.start << "]` "
+      case mention
+      when Discord::Mention::User
+        string.puts "**User:** #{mention.id}"
+      when Discord::Mention::Role
+        string.puts "**Role:** #{mention.id}"
+      when Discord::Mention::Channel
+        string.puts "**Channel:** #{mention.id}"
+      when Discord::Mention::Emoji
+        string << "**Emoji:** #{mention.name} #{mention.id}"
+        string << " (animated)" if mention.animated
+        string.puts
+      when Discord::Mention::Everyone
+        string.puts "**Everyone**"
+      when Discord::Mention::Here
+        string.puts "**Here**"
+      end
+    end
+  end
+
+  mentions = "no mentions found in your message" if mentions.empty?
+
+  begin
+    client.create_message(
+      payload.channel_id,
+      mentions)
+  rescue ex
+    client.create_message(
+      payload.channel_id,
+      "`#{ex.inspect}`")
+    raise ex
+  end
+end
+
+client.run

--- a/spec/mention_spec.cr
+++ b/spec/mention_spec.cr
@@ -1,0 +1,50 @@
+require "./spec_helper"
+
+def it_parses_message(string, into expected)
+  it "parses #{string.inspect} into #{expected}" do
+    parsed = Discord::Mention.parse(string)
+    parsed.should eq expected
+  end
+end
+
+describe Discord::Mention do
+  describe ".parse" do
+    it_parses_message(
+      "<@123><@!456>",
+      into: [
+        Discord::Mention::User.new(123_u64, 0, 6),
+        Discord::Mention::User.new(456_u64, 6, 7),
+      ]
+    )
+
+    it_parses_message(
+      "<@&123>",
+      into: [Discord::Mention::Role.new(123_u64, 0, 6)])
+
+    it_parses_message(
+      "<#123>",
+      into: [Discord::Mention::Channel.new(123_u64, 0, 6)])
+
+    it_parses_message(
+      "<:foo:123><a:bar:456>",
+      into: [
+        Discord::Mention::Emoji.new(false, "foo", 123_u64, 0, 10),
+        Discord::Mention::Emoji.new(true, "bar", 456_u64, 10, 11),
+      ]
+    )
+
+    it_parses_message(
+      "@everyone@here",
+      into: [
+        Discord::Mention::Everyone.new(0),
+        Discord::Mention::Here.new(9),
+      ]
+    )
+
+    context "with invalid mentions" do
+      it_parses_message(
+        "<<@123<@?123><#123<:foo:123<b:foo:123><@abc><@!abc>",
+        into: [] of Discord::Mention)
+    end
+  end
+end

--- a/src/discordcr/mention.cr
+++ b/src/discordcr/mention.cr
@@ -1,0 +1,129 @@
+module Discord::Mention
+  record User, id : UInt64, start : Int32, size : Int32
+
+  record Role, id : UInt64, start : Int32, size : Int32
+
+  record Channel, id : UInt64, start : Int32, size : Int32
+
+  record Emoji, animated : Bool, name : String, id : UInt64, start : Int32, size : Int32
+
+  record Everyone, start : Int32 do
+    def size
+      9
+    end
+  end
+
+  record Here, start : Int32 do
+    def size
+      5
+    end
+  end
+
+  alias MentionType = User | Role | Channel | Emoji | Everyone | Here
+
+  # Returns an array of mentions found in a string
+  def self.parse(string : String)
+    Parser.new(string).parse
+  end
+
+  # Parses a string for mentions, yielding for each mention found
+  def self.parse(string : String, &block : MentionType ->)
+    Parser.new(string).parse(&block)
+  end
+
+  # :nodoc:
+  class Parser
+    def initialize(@string : String)
+      @reader = Char::Reader.new string
+    end
+
+    delegate has_next?, pos, current_char, next_char, peek_next_char, to: @reader
+
+    def parse(&block : MentionType ->)
+      while has_next?
+        start = pos
+        animated = false
+
+        case current_char
+        when '<'
+          case next_char
+          when '@'
+            case peek_next_char
+            when '&'
+              next_char # Skip role mention indicator
+
+              if next_char.ascii_number?
+                snowflake = scan_snowflake(pos)
+                yield Role.new(snowflake, start, pos - start) if has_next? && current_char == '>'
+              end
+            when .ascii_number?, '!'
+              next_char                        # Skip mention indicator
+              next_char if current_char == '!' # Skip optional nickname indicator
+
+              if current_char.ascii_number?
+                snowflake = scan_snowflake(pos)
+                yield User.new(snowflake, start, pos - start + 1) if current_char == '>'
+              end
+            end
+          when '#'
+            next_char # Skip channel mention indicator
+
+            if peek_next_char.ascii_number?
+              snowflake = scan_snowflake(pos)
+              yield Channel.new(snowflake, start, pos - start + 1) if current_char == '>'
+            end
+          when ':', 'a'
+            if current_char == 'a'
+              next unless peek_next_char == ':'
+              animated = true
+              next_char
+            end
+            next_char
+
+            name = scan_word(pos)
+            if current_char == ':' && peek_next_char.ascii_number?
+              next_char
+              snowflake = scan_snowflake(pos)
+              yield Emoji.new(animated, name, snowflake, start, pos - start + 1) if current_char == '>'
+            end
+          end
+        when '@'
+          word = scan_word(pos)
+          case word
+          when "@everyone"
+            yield Everyone.new(start)
+          when "@here"
+            yield Here.new(start)
+          end
+        else
+          next_char
+        end
+      end
+    end
+
+    def parse
+      results = [] of MentionType
+      parse { |mention| results << mention }
+      results
+    end
+
+    private def scan_snowflake(start)
+      while next_char.ascii_number?
+        # Nothing to do
+      end
+      @string[start..pos - 1].to_u64
+    end
+
+    private def scan_word(start)
+      while has_next?
+        case next_char
+        when .ascii_letter?, .ascii_number?
+          # Nothing to do
+        else
+          break
+        end
+      end
+      @string[start..pos - 1]
+    end
+  end
+end


### PR DESCRIPTION
Refactoring of #64 

I ended up liking this a lot better than imposing an API over `Message`, as there's times when your content may not be coming from Discord (database, cache). If we still want that (`Message#parse_mentions`) that is trivial to add.

From the feedback in #64, this has:
- Stronger typing; structs for each mention type instead of an enum, methods specific to each mention type.
- Each mention type has `#position` and `#size`
- A few specs
- Support for the new animated flag in custom emoji mentions

Notes:
- ~~I was unsure about the `#not_nil!` assertion on `Regex::MatchData#begin`, as I couldn't think of when in this implementation it would ever be nil.~~ N/A in parser refactor
- @RX14 , you had wanted `#user_mentions`, etc. - I missed this when I refactored it, but I thought it might be a bit much to wrap a simple `#select`, or I couldn't think of a use case where the block-case variant would work just as well. Let me know what you think.
- ~~Should the block-accepting `Mention.parse` still return an `Array(MentionType)`?~~ N/A in parser refactor

Closes #35 