### PR TITLE
Setup heartbeats in #run, not #initialize

### DIFF
--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -27,6 +27,9 @@ module Discord
     # a voice client, for example
     getter session : Gateway::Session?
 
+    # Used if operating in sharded mode.
+    property shard : Gateway::ShardKey?
+
     @websocket : Discord::WebSocket
     @backoff : Float64
 
@@ -65,7 +68,7 @@ module Discord
     # properties. It's not recommended to change these from the default values,
     # but if you desire to do so, you can.
     def initialize(@token : String, @client_id : UInt64? = nil,
-                   @shard : Gateway::ShardKey? = nil,
+                   @shard : Gateway::ShardKey? = {shard_id: 0, num_shards: 1},
                    @large_threshold : Int32 = 100,
                    @compress : Bool = false,
                    @properties : Gateway::IdentifyProperties = DEFAULT_PROPERTIES)

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -28,7 +28,7 @@ module Discord
     getter session : Gateway::Session?
 
     # Used if operating in sharded mode.
-    property shard : Gateway::ShardKey?
+    property shard : Gateway::ShardKey
 
     @websocket : Discord::WebSocket
     @backoff : Float64
@@ -68,7 +68,7 @@ module Discord
     # properties. It's not recommended to change these from the default values,
     # but if you desire to do so, you can.
     def initialize(@token : String, @client_id : UInt64? = nil,
-                   @shard : Gateway::ShardKey? = {shard_id: 0, num_shards: 1},
+                   @shard : Gateway::ShardKey = {shard_id: 0, num_shards: 1},
                    @large_threshold : Int32 = 100,
                    @compress : Bool = false,
                    @properties : Gateway::IdentifyProperties = DEFAULT_PROPERTIES)
@@ -267,9 +267,7 @@ module Discord
     end
 
     private def identify
-      if shard = @shard
-        shard_tuple = shard.values
-      end
+      shard_tuple = shard.values
 
       packet = Gateway::IdentifyPacket.new(@token, @properties, @compress, @large_threshold, shard_tuple)
       @websocket.send(packet.to_json)

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -81,8 +81,6 @@ module Discord
       # Initially, this flag is set to true so the client doesn't immediately
       # try to reconnect at the next heartbeat.
       @last_heartbeat_acked = true
-
-      setup_heartbeats
     end
 
     # Returns this client's ID as provided in its associated Oauth2 application.
@@ -96,6 +94,7 @@ module Discord
     # do anything beyond making REST API calls. Calling this method will block
     # execution until the bot is forcibly stopped.
     def run
+      setup_heartbeats
       loop do
         begin
           @websocket.run


### PR DESCRIPTION
GET /gateway/bot requires authorization, so
for sharding, one has to create a throwaway
client to authenticate and get the recommended
number of shards.

This commit prevents heartbeat setup from
actually running until needed.