### PR TITLE
Add get_gateway_bot

### DIFF
--- a/src/discordcr/mappings/rest.cr
+++ b/src/discordcr/mappings/rest.cr
@@ -9,6 +9,14 @@ module Discord
       )
     end
 
+    # A response to the Get Gateway Bot REST API call.
+    struct GatewayBotResponse
+      JSON.mapping(
+        url: String,
+        shards: Int32
+      )
+    end
+
     # A response to the Get Guild Prune Count REST API call.
     struct PruneCountResponse
       JSON.mapping(

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -124,6 +124,22 @@ module Discord
       GatewayResponse.from_json(response.body)
     end
 
+    # Gets the gateway Bot URL to connect to, and the recommended amount of shards to make.
+    #
+    # [API docs for this method](https://discordapp.com/developers/docs/topics/gateway#get-gateway-bot)
+    def get_gateway_bot
+      response = request(
+        :gateway_bot,
+        nil,
+        "GET",
+        "/gateway/bot",
+        HTTP::Headers.new,
+        nil
+      )
+
+      GatewayBotResponse.from_json(response.body)
+    end
+
     # Gets the OAuth2 application tied to a client.
     #
     # [API docs for this method](https://discordapp.com/developers/docs/topics/oauth2#get-current-application-information)


### PR DESCRIPTION
Add `GET /gateway/bot` endpoint.

Note that without #124, setting up sharded clients will require doing heartbeat setup twice.