### PR TITLE
Add Client#stop

### DIFF
--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -82,6 +82,9 @@ module Discord
       # try to reconnect at the next heartbeat.
       @last_heartbeat_acked = true
 
+      # If the websocket is closed, whether we should immediately try and reconnect
+      @should_reconnect = true
+
       setup_heartbeats
     end
 
@@ -109,11 +112,19 @@ module Discord
         @send_heartbeats = false
         @session.try &.suspend
 
+        break unless @should_reconnect
+
         wait_for_reconnect
 
         LOGGER.info "Reconnecting"
         @websocket = initialize_websocket
       end
+    end
+
+    # Closes the gateway connection permanently
+    def stop(message = nil)
+      @should_reconnect = false
+      @websocket.close(message)
     end
 
     # Separate method to wait an ever-increasing amount of time before reconnecting after being disconnected in an


### PR DESCRIPTION
At the moment there's no way to completely halt a running client. The websocket isn't exposed publicly, so you have to hack via `client.@websocket.close` or similar, but even then it will try to reconnect after `@backoff`.