### PR TITLE
Fix REST#add_guild_member when user is already a member

### DIFF
--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -871,7 +871,11 @@ module Discord
         json
       )
 
-      GuildMember.from_json(response.body)
+      if response.status_code == 201
+        GuildMember.from_json(response.body)
+      else
+        nil
+      end
     end
 
     # Changes a specific member's properties. Requires:


### PR DESCRIPTION
The API returns `204 No Content` if the user is already a member of the guild. (This isn't documented in the API docs :disappointed: )