### PR TITLE
Changes for Crystal 0.25

### DIFF
--- a/spec/discordcr_spec.cr
+++ b/spec/discordcr_spec.cr
@@ -61,7 +61,7 @@ describe Discord do
     end
 
     it "serializes" do
-      json = %({"data":"2017-11-16T13:09:18.291+00:00"})
+      json = %({"data":"2017-11-16T13:09:18.291000+00:00"})
       obj = StructWithTime.from_json(json)
       obj.to_json.should eq json
     end

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -129,7 +129,7 @@ module Discord
       type: String,
       description: String?,
       url: String?,
-      timestamp: {type: Time?, converter: EmbedTimestampConverter},
+      timestamp: {type: Time?, converter: TimestampConverter},
       colour: {type: UInt32?, key: "color"},
       footer: EmbedFooter?,
       image: EmbedImage?,

--- a/src/discordcr/mappings/converters.cr
+++ b/src/discordcr/mappings/converters.cr
@@ -8,9 +8,9 @@ module Discord
       time_str = parser.read_string
 
       begin
-        Time::Format.new("%FT%T.%L%:z", Time::Kind::Utc).parse(time_str)
+        Time::Format.new("%FT%T.%6N%:z").parse(time_str)
       rescue Time::Format::Error
-        Time::Format.new("%FT%T%:z", Time::Kind::Utc).parse(time_str)
+        Time::Format.new("%FT%T%:z").parse(time_str)
       end
     end
 

--- a/src/discordcr/mappings/converters.cr
+++ b/src/discordcr/mappings/converters.cr
@@ -15,21 +15,7 @@ module Discord
     end
 
     def self.to_json(value : Time, builder : JSON::Builder)
-      Time::Format.new("%FT%T.%L%:z").to_json(value, builder)
-    end
-  end
-
-  # :nodoc:
-  module EmbedTimestampConverter
-    SEND_FORMAT    = Time::Format.new("%FT%T%:z")
-    RECEIVE_FORMAT = Time::Format.new("%FT%TZ")
-
-    def self.from_json(parser : JSON::PullParser) : Time
-      SEND_FORMAT.from_json(parser)
-    end
-
-    def self.to_json(value : Time, builder : JSON::Builder)
-      RECEIVE_FORMAT.to_json(value.to_utc, builder)
+      Time::Format.new("%FT%T.%6N%:z").to_json(value, builder)
     end
   end
 

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -96,7 +96,7 @@ module Discord
       user: User,
       nick: String?,
       roles: {type: Array(UInt64), converter: SnowflakeArrayConverter},
-      joined_at: {type: Time?, converter: Time::Format::ISO_8601_DATE},
+      joined_at: {type: Time?, converter: TimestampConverter},
       deaf: Bool?,
       mute: Bool?
     )

--- a/src/discordcr/mappings/invite.cr
+++ b/src/discordcr/mappings/invite.cr
@@ -20,7 +20,7 @@ module Discord
       max_uses: UInt32,
       max_age: UInt32,
       temporary: Bool,
-      created_at: {type: Time, converter: Time::Format::ISO_8601_DATE},
+      created_at: {type: Time, converter: TimestampConverter},
       revoked: Bool
     )
   end

--- a/src/discordcr/voice.cr
+++ b/src/discordcr/voice.cr
@@ -291,7 +291,7 @@ module Discord
   # there will be no delay: the next iteration follows immediately, with no
   # attempt to get in sync.
   def self.every(time_span : Time::Span)
-    loop do |i|
+    loop do
       timed_run(time_span) { yield }
     end
   end


### PR DESCRIPTION
Surpasses #114 (that change is actually wrong)

The location of timestamps is now parsed out of the format, specifying `Kind` (or its successor, `Location`) is not necessary.

Additionally, the formats between `TimestampConverter` and `EmbedTimestampConverter` were so similar and compatible, that I've removed it and use `TimestampConverter` everywhere.

I also do this because `Time::Format::ISO_8601_DATE`/`DATE_TIME` no longer defines `.from_json`/`.to_json`. 

I've tested this for a while on a live connection as well as some chat logs I had laying around on disk from previous issues with parsing timestamps with no issues.