### PR TITLE
Fix Snowflake interpolation, mention_roles type

### DIFF
--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -309,7 +309,7 @@ module Discord
         tts: Bool?,
         mention_everyone: Bool?,
         mentions: Array(User)?,
-        mention_roles: Array(Snowflake),
+        mention_roles: Array(Snowflake)?,
         attachments: Array(Attachment)?,
         embeds: Array(Embed)?,
         pinned: Bool?

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -225,7 +225,7 @@ module Discord
     # Message History" permission.
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/channel#get-channel-messages)
-    def get_channel_messages(channel_id : UInt64 | Snowflake, limit : UInt8 = 50, before : UInt64 | Snowflake | Nil = nil, after : UInt64 | Snowflak | Nil = nil, around : UInt64 | Snowflake | Nil = nil)
+    def get_channel_messages(channel_id : UInt64 | Snowflake, limit : UInt8 = 50, before : UInt64 | Snowflake | Nil = nil, after : UInt64 | Snowflake | Nil = nil, around : UInt64 | Snowflake | Nil = nil)
       path = "/channels/#{channel_id}/messages?limit=#{limit}"
       path += "&before=#{before}" if before
       path += "&after=#{after}" if after

--- a/src/discordcr/snowflake.cr
+++ b/src/discordcr/snowflake.cr
@@ -31,6 +31,10 @@ module Discord
       @value
     end
 
+    def to_s(io : IO)
+      io << @value
+    end
+
     # The time at which this snowflake was created
     def creation_time
       ms = (value >> 22) + DISCORD_EPOCH


### PR DESCRIPTION
Updated my main bot to v0.4 and got some leftover things from #130 (Sorry! :disappointed:)

Right now `Snowflake` doesn't interpolate into HTTP routes well, so using `Snowflakes` in `REST` fails. I've fixed this by `def to_s(io : IO)`, writing the internal `@value`.
```cr
# current:
s = Discord::Snowflake.new(123_u64)
puts "/some/#{s}/route" # => "/some/Discord::Snowflake(@value=123_u64)/route"

# fixed:
s = Discord::Snowflake.new(123_u64)
puts "/some/#{s}/route" # => "/some/123/route"
```
Workaround is to use, i.e., `message.channel_id.to_u64` (or patch this yourself)

Secondly, looks like I just missed the `?` in subbing out an `Array(UInt64)?` type restriction. I reviewed #130 again and it looks like this is the only one I missed.