### PR TITLE
Snowflake is comparable to UInt64

### DIFF
--- a/spec/snowflake_spec.cr
+++ b/spec/snowflake_spec.cr
@@ -40,4 +40,10 @@ describe Discord::Snowflake do
       snowflake.creation_time.should eq time
     end
   end
+
+  it "compares to uint64" do
+    snowflake = Discord::Snowflake.new(1_u64)
+    (snowflake == 1_u64).should be_true
+    (snowflake == 0_u64).should be_false
+  end
 end

--- a/src/discordcr/snowflake.cr
+++ b/src/discordcr/snowflake.cr
@@ -4,6 +4,7 @@ module Discord
   # Struct representing a Discord ID
   struct Snowflake
     include Comparable(Snowflake)
+    include Comparable(UInt64)
 
     getter value : UInt64
 
@@ -43,6 +44,10 @@ module Discord
 
     def <=>(other : Snowflake)
       value <=> other.value
+    end
+
+    def <=>(int : UInt64)
+      value <=> int
     end
   end
 end


### PR DESCRIPTION
This makes Snowflake a little easier to work with for a common simple use case, comparing to a known literal value:

```cr
client.on_message_create do |payload|
  next unless payload.author.id == 120571255635181568_u64
  # Only process messages from z64 here
end
```
Currently you need to do `payload.author.id.to_u64`, etc.