### PR TITLE
Remove MessageTypeConverter, ChannelTypeConverter

### DIFF
--- a/spec/discordcr_spec.cr
+++ b/spec/discordcr_spec.cr
@@ -9,13 +9,13 @@ end
 
 struct StructWithMessageType
   JSON.mapping(
-    data: {type: Discord::MessageType, converter: Discord::MessageTypeConverter}
+    data: Discord::MessageType
   )
 end
 
 struct StructWithChannelType
   JSON.mapping(
-    data: {type: Discord::ChannelType, converter: Discord::ChannelTypeConverter}
+    data: Discord::ChannelType
   )
 end
 
@@ -67,7 +67,7 @@ describe Discord do
     end
   end
 
-  describe Discord::MessageTypeConverter do
+  describe Discord::MessageType do
     it "converts an integer into a MessageType" do
       json = %({"data": 0})
 
@@ -79,7 +79,7 @@ describe Discord do
       it "raises" do
         json = %({"data":"foo"})
 
-        expect_raises(Exception, %(Unexpected message type value: "foo")) do
+        expect_raises(ArgumentError, "Unknown enum Discord::MessageType value: foo") do
           StructWithMessageType.from_json(json)
         end
       end
@@ -93,7 +93,7 @@ describe Discord do
     end
   end
 
-  describe Discord::ChannelTypeConverter do
+  describe Discord::ChannelType do
     it "converts an integer into a ChannelType" do
       json = %({"data": 0})
 
@@ -105,7 +105,7 @@ describe Discord do
       it "raises" do
         json = %({"data":"foo"})
 
-        expect_raises(Exception, %(Unexpected channel type value: "foo")) do
+        expect_raises(ArgumentError, "Unknown enum Discord::ChannelType value: foo") do
           StructWithChannelType.from_json(json)
         end
       end

--- a/spec/discordcr_spec.cr
+++ b/spec/discordcr_spec.cr
@@ -7,18 +7,6 @@ struct StructWithTime
   )
 end
 
-struct StructWithMessageType
-  JSON.mapping(
-    data: Discord::MessageType
-  )
-end
-
-struct StructWithChannelType
-  JSON.mapping(
-    data: Discord::ChannelType
-  )
-end
-
 describe Discord do
   describe "VERSION" do
     it "matches shards.yml" do
@@ -67,48 +55,10 @@ describe Discord do
     end
   end
 
-  describe Discord::MessageType do
-    it "converts an integer into a MessageType" do
-      json = %({"data": 0})
-
-      obj = StructWithMessageType.from_json(json)
-      obj.data.should eq Discord::MessageType::Default
-    end
-
-    context "with an invalid json value" do
-      it "raises" do
-        json = %({"data":"foo"})
-
-        expect_raises(ArgumentError, "Unknown enum Discord::MessageType value: foo") do
-          StructWithMessageType.from_json(json)
-        end
-      end
-    end
-  end
-
   describe Discord::WebSocket::Packet do
     it "inspects" do
       packet = Discord::WebSocket::Packet.new(0_i64, 1_i64, IO::Memory.new("foo"), "test")
       packet.inspect.should eq %(Discord::WebSocket::Packet(@opcode=0_i64 @sequence=1_i64 @data="foo" @event_type="test"))
-    end
-  end
-
-  describe Discord::ChannelType do
-    it "converts an integer into a ChannelType" do
-      json = %({"data": 0})
-
-      obj = StructWithChannelType.from_json(json)
-      obj.data.should eq Discord::ChannelType::GuildText
-    end
-
-    context "with an invalid json value" do
-      it "raises" do
-        json = %({"data":"foo"})
-
-        expect_raises(ArgumentError, "Unknown enum Discord::ChannelType value: foo") do
-          StructWithChannelType.from_json(json)
-        end
-      end
     end
   end
 end

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -14,7 +14,7 @@ module Discord
 
   struct Message
     JSON.mapping(
-      type: {type: MessageType, converter: MessageTypeConverter},
+      type: MessageType,
       content: String,
       id: Snowflake,
       channel_id: Snowflake,
@@ -64,7 +64,7 @@ module Discord
 
     JSON.mapping(
       id: Snowflake,
-      type: {type: ChannelType, converter: ChannelTypeConverter},
+      type: ChannelType,
       guild_id: Snowflake?,
       name: String?,
       permission_overwrites: Array(Overwrite)?,
@@ -85,7 +85,7 @@ module Discord
   struct PrivateChannel
     JSON.mapping(
       id: Snowflake,
-      type: {type: ChannelType, converter: ChannelTypeConverter},
+      type: ChannelType,
       recipients: Array(User),
       last_message_id: Snowflake?
     )

--- a/src/discordcr/mappings/converters.cr
+++ b/src/discordcr/mappings/converters.cr
@@ -18,30 +18,4 @@ module Discord
       Time::Format.new("%FT%T.%6N%:z").to_json(value, builder)
     end
   end
-
-  # :nodoc:
-  module MessageTypeConverter
-    def self.from_json(parser : JSON::PullParser)
-      if value = parser.read?(UInt8)
-        MessageType.new(value)
-      else
-        raise "Unexpected message type value: #{parser.read_raw}"
-      end
-    end
-
-    def self.to_json(value : MessageType, builder : JSON::Builder)
-      value.to_json(builder)
-    end
-  end
-
-  # :nodoc:
-  module ChannelTypeConverter
-    def self.from_json(parser : JSON::PullParser)
-      if value = parser.read?(UInt8)
-        ChannelType.new(value)
-      else
-        raise "Unexpected channel type value: #{parser.read_raw}"
-      end
-    end
-  end
 end


### PR DESCRIPTION
Some more general cleanup. These aren't necessary as Crystal stdlib already handles JSON serde for `enum`.

The first commit removes the converters and fixes the specs. The second commit removes the specs, which I can drop if desired. Didn't see the point in keeping them around unless we are going to test all of our other types, but this is duplicating coverage we already get from the stdlib.

This also fixes some types not being able to be serialized because the converters didn't define `.to_json(value, builder)` (cc @velddev)