### PR TITLE
Implement MaybeTimestampConverter

### DIFF
--- a/spec/discordcr_spec.cr
+++ b/spec/discordcr_spec.cr
@@ -7,6 +7,12 @@ struct StructWithTime
   )
 end
 
+struct StructWithMaybeTime
+  JSON.mapping(
+    data: {type: Time?, converter: Discord::MaybeTimestampConverter, emit_null: true}
+  )
+end
+
 struct StructWithMessageType
   JSON.mapping(
     data: {type: Discord::MessageType, converter: Discord::MessageTypeConverter}
@@ -53,6 +59,30 @@ describe Discord do
       expect_raises(JSON::ParseException) do
         StructWithTime.from_json(json)
       end
+    end
+  end
+
+  describe Discord::MaybeTimestampConverter do
+    it "parses a time" do
+      json = %({"data":"2017-11-16T13:09:18.291000+00:00"})
+      StructWithMaybeTime.from_json(json).data.should be_a Time
+    end
+
+    it "parses null" do
+      json = %({"data":null})
+      StructWithMaybeTime.from_json(json).data.should be_nil
+    end
+
+    it "serializes a time" do
+      json = %({"data":"2017-11-16T13:09:18.291000+00:00"})
+      obj = StructWithMaybeTime.from_json(json)
+      obj.to_json.should eq json
+    end
+
+    it "serializes null" do
+      json = %({"data":null})
+      obj = StructWithMaybeTime.from_json(json)
+      obj.to_json.should eq json
     end
   end
 

--- a/spec/discordcr_spec.cr
+++ b/spec/discordcr_spec.cr
@@ -47,6 +47,13 @@ describe Discord do
       obj = StructWithTime.from_json(json)
       obj.to_json.should eq json
     end
+
+    it "raises on null" do
+      json = %({"data":null})
+      expect_raises(JSON::ParseException) do
+        StructWithTime.from_json(json)
+      end
+    end
   end
 
   describe Discord::REST::ModifyChannelPositionPayload do

--- a/src/discordcr/mappings/channel.cr
+++ b/src/discordcr/mappings/channel.cr
@@ -129,7 +129,7 @@ module Discord
       type: String,
       description: String?,
       url: String?,
-      timestamp: {type: Time?, converter: TimestampConverter},
+      timestamp: {type: Time?, converter: MaybeTimestampConverter},
       colour: {type: UInt32?, key: "color"},
       footer: EmbedFooter?,
       image: EmbedImage?,

--- a/src/discordcr/mappings/converters.cr
+++ b/src/discordcr/mappings/converters.cr
@@ -20,6 +20,25 @@ module Discord
   end
 
   # :nodoc:
+  module MaybeTimestampConverter
+    def self.from_json(parser : JSON::PullParser)
+      if parser.kind == :null
+        parser.read_null
+        return nil
+      end
+      TimestampConverter.from_json(parser)
+    end
+
+    def self.to_json(value : Time?, builder : JSON::Builder)
+      if value
+        TimestampConverter.to_json(value, builder)
+      else
+        builder.null
+      end
+    end
+  end
+
+  # :nodoc:
   module MessageTypeConverter
     def self.from_json(parser : JSON::PullParser)
       if value = parser.read?(UInt8)

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -238,7 +238,7 @@ module Discord
         user: User,
         nick: String?,
         roles: Array(Snowflake),
-        joined_at: {type: Time?, converter: TimestampConverter},
+        joined_at: {type: Time?, converter: MaybeTimestampConverter},
         deaf: Bool,
         mute: Bool,
         guild_id: Snowflake
@@ -305,7 +305,7 @@ module Discord
         id: Snowflake,
         channel_id: Snowflake,
         author: User?,
-        timestamp: {type: Time?, converter: TimestampConverter},
+        timestamp: {type: Time?, converter: MaybeTimestampConverter},
         tts: Bool?,
         mention_everyone: Bool?,
         mentions: Array(User)?,

--- a/src/discordcr/mappings/gateway.cr
+++ b/src/discordcr/mappings/gateway.cr
@@ -366,7 +366,7 @@ module Discord
 
     struct ChannelPinsUpdatePayload
       JSON.mapping(
-        last_pin_timestamp: {type: Time, converter: TimestampConverter},
+        last_pin_timestamp: {type: Time?, converter: MaybeTimestampConverter},
         channel_id: Snowflake
       )
     end

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -96,7 +96,7 @@ module Discord
       user: User,
       nick: String?,
       roles: Array(Snowflake),
-      joined_at: {type: Time?, converter: TimestampConverter},
+      joined_at: {type: Time?, converter: MaybeTimestampConverter},
       deaf: Bool?,
       mute: Bool?
     )


### PR DESCRIPTION
There are some spots where we use `Time?` that use `TimestampConverter`, which (although I've yet to ever see it happen for these fields\*) will fail if they are null.

This adds `MaybeTimestampConverter` which simply wraps `TimestampConverter` over `parser.kind` to return `Time?` to avoid duplicating code.

\* - This also fixes one instance of wrong mapping type in `ChannelPinsUpdatePayload`.