### PR TITLE
Fix return type for Cache#resolve_dm_channel

### DIFF
--- a/src/discordcr/cache.cr
+++ b/src/discordcr/cache.cr
@@ -129,7 +129,7 @@ module Discord
       @dm_channels.fetch(recipient_id) do
         channel = @client.create_dm(recipient_id)
         cache(Channel.new(channel))
-        channel.id
+        channel.id.to_u64
       end
     end
 


### PR DESCRIPTION
Introduced with change to Discord::Snowflake

(Actually I'm not sure whether it should be returning a UInt64 or Discord::Snowflake, but this is what I (was) expecting)