### PR TITLE
Implement Discord::Paginator

### DIFF
--- a/spec/paginator_spec.cr
+++ b/spec/paginator_spec.cr
@@ -1,0 +1,63 @@
+require "./spec_helper"
+
+describe Discord::Paginator do
+  context "direction up" do
+    it "requests all pages until empty" do
+      data = {
+        [1, 2, 3],
+        [4, 5],
+        [] of Int32,
+        [6, 7],
+      }
+
+      index = 0
+      paginator = Discord::Paginator(Int32).new(nil, :down) do |last_page|
+        if last_page
+          last_page.should eq data[index - 1]
+        end
+        index += 1
+        data[index - 1]
+      end
+
+      paginator.to_a.should eq [1, 2, 3, 4, 5]
+    end
+  end
+
+  context "direction down" do
+    it "requests all pages until empty" do
+      data = {
+        [6, 7],
+        [4, 5],
+        [] of Int32,
+        [1, 2, 3],
+      }
+
+      index = 0
+      paginator = Discord::Paginator(Int32).new(nil, :up) do |last_page|
+        if last_page
+          last_page.should eq data[index - 1]
+        end
+        index += 1
+        data[index - 1]
+      end
+
+      paginator.to_a.should eq [7, 6, 5, 4]
+    end
+  end
+
+  it "only returns up to limit items" do
+    data = {
+      [1, 2, 3],
+      [4, 5],
+      [] of Int32,
+    }
+
+    index = 0
+    paginator = Discord::Paginator(Int32).new(2, :down) do |last_page|
+      index += 1
+      data[index - 1]
+    end
+
+    paginator.to_a.should eq [1, 2]
+  end
+end

--- a/src/discordcr/paginator.cr
+++ b/src/discordcr/paginator.cr
@@ -1,0 +1,40 @@
+# :nodoc:
+module Discord
+  class Paginator(T)
+    include ::Enumerable(T)
+
+    enum Direction
+      Up
+      Down
+    end
+
+    def initialize(@limit : Int32?, @direction : Direction,
+                   &@block : Array(T)? -> Array(T))
+      @count = 0
+    end
+
+    def each
+      last_page = nil
+      loop do
+        page = @block.call(last_page)
+        return if page.empty?
+
+        if @direction.up?
+          page.reverse_each do |item|
+            yield(item)
+            @count += 1
+            @limit.try { |l| return if @count >= l }
+          end
+        else
+          page.each do |item|
+            yield(item)
+            @count += 1
+            @limit.try { |l| return if @count >= l }
+          end
+        end
+
+        last_page = page
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements a paginator utility class for making requests across paginated endpoints seamlessly.

This is useful for:
-  fetching large volumes of channel history for backfilling a chat log database 
- a means of examining all of the guilds a client is in if they're in more than 100
- listing all of the members of a guild if there are more than 1000

---

Example:

```cr
client.page_channel_messages(381889335278043137, limit: 20, page_size: 5).each do |message|
  p({message.id.to_u64, message.author.username, message.content})
end
```
([Results](https://gist.github.com/z64/74413410bc11623d857e8aee191a5abc))

Closes #140 