### PR TITLE
Add utility methods for CDN resources

### DIFF
--- a/spec/cdn_spec.cr
+++ b/spec/cdn_spec.cr
@@ -58,3 +58,151 @@ describe Discord::CDN do
     end
   end
 end
+
+describe Discord::User do
+  user_with_default_avatar = Discord::User.from_json <<-JSON
+  {
+    "id": "1",
+    "username": "foo",
+    "avatar": null,
+    "discriminator": "0007"
+  }
+  JSON
+
+  user_with_avatar = Discord::User.from_json <<-JSON
+  {
+    "id": "1",
+    "username": "foo",
+    "avatar": "hash",
+    "discriminator": "0007"
+  }
+  JSON
+
+  user_with_animated_avatar = Discord::User.from_json <<-JSON
+  {
+    "id": "1",
+    "username": "foo",
+    "avatar": "a_hash",
+    "discriminator": "0007"
+  }
+  JSON
+
+  describe "#avatar_url" do
+    it "returns avatar URL with the given format and size" do
+      user = user_with_avatar
+      user.avatar_url(:png, 16).should eq Discord::CDN.user_avatar(user.id, user.avatar.not_nil!, :png, 16)
+    end
+
+    it "returns default avatar URL with the given format and size" do
+      user = user_with_default_avatar
+      user.avatar_url(:png, 16).should eq Discord::CDN.default_user_avatar(user.discriminator)
+    end
+
+    context "without format" do
+      it "returns default avatar URL" do
+        user = user_with_default_avatar
+        user.avatar_url.should eq Discord::CDN.default_user_avatar(user.discriminator)
+      end
+
+      it "returns avatar URL" do
+        user = user_with_avatar
+        user.avatar_url.should eq Discord::CDN.user_avatar(user.id, user.avatar.not_nil!)
+      end
+
+      it "returns animated avatar URL" do
+        user = user_with_animated_avatar
+        user.avatar_url.should eq Discord::CDN.user_avatar(user.id, user.avatar.not_nil!)
+      end
+    end
+  end
+end
+
+describe Discord::Guild do
+  guild_with_icon_and_splash = Discord::Guild.from_json <<-JSON
+  {
+    "id": "1",
+    "name": "name",
+    "icon": "hash",
+    "splash": "hash",
+    "owner_id": "2",
+    "region": "region",
+    "verification_level": 1,
+    "roles": [],
+    "emojis": [],
+    "features": [],
+    "default_message_notifications": 1,
+    "explicit_content_filter": 1
+  }
+  JSON
+
+  it "#icon_url" do
+    guild = guild_with_icon_and_splash
+    guild.icon_url(:png, 16).should eq Discord::CDN.guild_icon(guild.id, guild.icon.not_nil!, :png, 16)
+  end
+
+  it "#splash_url" do
+    guild = guild_with_icon_and_splash
+    guild.splash_url(:png, 16).should eq Discord::CDN.guild_splash(guild.id, guild.splash.not_nil!, :png, 16)
+  end
+end
+
+describe Discord::Emoji do
+  emoji = Discord::Emoji.from_json <<-JSON
+  {
+    "id": "1",
+    "name": "name",
+    "roles": [],
+    "require_colons": true,
+    "managed": false,
+    "animated": false
+  }
+  JSON
+
+  animated_emoji = Discord::Emoji.from_json <<-JSON
+  {
+    "id": "1",
+    "name": "name",
+    "roles": [],
+    "require_colons": true,
+    "managed": false,
+    "animated": true
+  }
+  JSON
+
+  describe "#image_url" do
+    it "returns an image URL with given format and size" do
+      emoji.image_url(:png, 16).should eq Discord::CDN.custom_emoji(emoji.id, :png, 16)
+    end
+
+    context "without format" do
+      it "returns a webp, or gif if animated" do
+        emoji.image_url.should eq Discord::CDN.custom_emoji(emoji.id, :png, 128)
+        animated_emoji.image_url.should eq Discord::CDN.custom_emoji(animated_emoji.id, :gif, 128)
+      end
+    end
+  end
+end
+
+describe Discord::OAuth2Application do
+  describe "#icon_url" do
+    application_with_icon = Discord::OAuth2Application.from_json <<-JSON
+    {
+      "id": "1",
+      "name": "name",
+      "icon": "hash",
+      "bot_public": true,
+      "bot_require_code_grant": false,
+      "owner": {
+        "id": "1",
+        "username": "username",
+        "discriminator": "0001"
+      }
+    }
+    JSON
+
+    it "returns a CDN URL with the given format and size" do
+      application = application_with_icon
+      application.icon_url(:png, 16).should eq Discord::CDN.application_icon(application.id, application.icon.not_nil!, :png, 16)
+    end
+  end
+end

--- a/spec/cdn_spec.cr
+++ b/spec/cdn_spec.cr
@@ -1,0 +1,60 @@
+require "./spec_helper"
+
+describe Discord::CDN do
+  it "builds a custom emoji URL" do
+    url = Discord::CDN.custom_emoji(1, :png, 16)
+    url.should eq "https://cdn.discordapp.com/emojis/1.png?size=16"
+  end
+
+  it "builds a guild icon URL" do
+    url = Discord::CDN.guild_icon(1, "hash", :png, 16)
+    url.should eq "https://cdn.discordapp.com/icons/1/hash.png?size=16"
+  end
+
+  it "builds a guild splash URL" do
+    url = Discord::CDN.guild_splash(1, "hash", :png, 16)
+    url.should eq "https://cdn.discordapp.com/splashes/1/hash.png?size=16"
+  end
+
+  it "builds a default user avatar URL" do
+    url = Discord::CDN.default_user_avatar("0001")
+    url.should eq "https://cdn.discordapp.com/embed/avatars/1.png"
+
+    url = Discord::CDN.default_user_avatar("0007")
+    url.should eq "https://cdn.discordapp.com/embed/avatars/2.png"
+  end
+
+  describe "user_avatar" do
+    it "builds a user avatar URL" do
+      url = Discord::CDN.user_avatar(1, "hash", :png, 16)
+      url.should eq "https://cdn.discordapp.com/avatars/1/hash.png?size=16"
+    end
+
+    context "without format" do
+      it "detects an animated avatar" do
+        url = Discord::CDN.user_avatar(1, "a_hash", 16)
+        url.should eq "https://cdn.discordapp.com/avatars/1/a_hash.gif?size=16"
+      end
+
+      it "defaults to webp" do
+        url = Discord::CDN.user_avatar(1, "hash", 16)
+        url.should eq "https://cdn.discordapp.com/avatars/1/hash.webp?size=16"
+      end
+    end
+  end
+
+  it "builds an application icon URL" do
+    url = Discord::CDN.application_icon(1, "hash", :png, 16)
+    url.should eq "https://cdn.discordapp.com/app-icons/1/hash.png?size=16"
+  end
+
+  it "raises on an invalid size" do
+    expect_raises(ArgumentError, "Size 17 is not between 16 and 2048 and a power of 2") do
+      Discord::CDN.custom_emoji(1, :png, 17)
+    end
+
+    expect_raises(ArgumentError, "Size 0 is not between 16 and 2048 and a power of 2") do
+      Discord::CDN.custom_emoji(1, :png, 0)
+    end
+  end
+end

--- a/src/discordcr/cdn.cr
+++ b/src/discordcr/cdn.cr
@@ -1,6 +1,9 @@
 # This module contains methods for building URLs to resources on Discord's CDN
 # for things like guild icons and avatars.
 #
+# NOTE: All `size` arguments for CDN methods must be a power of 2 between 16
+# and 2048. If an invalid size is given, `ArgumentError` will be raised.
+#
 # [API Documentation for image formatting](https://discordapp.com/developers/docs/reference#image-formatting)
 module Discord::CDN
   extend self
@@ -8,6 +11,7 @@ module Discord::CDN
   # Base CDN URL
   BASE_URL = "https://cdn.discordapp.com"
 
+  # Available image formats for custom emoji
   enum CustomEmojiFormat
     PNG
     GIF
@@ -26,6 +30,7 @@ module Discord::CDN
     end
   end
 
+  # Available image formats for guild icons
   enum GuildIconFormat
     PNG
     JPEG
@@ -47,6 +52,7 @@ module Discord::CDN
     end
   end
 
+  # Available image formats for guild splashes
   enum GuildSplashFormat
     PNG
     JPEG
@@ -68,6 +74,7 @@ module Discord::CDN
     end
   end
 
+  # Available image formats for user avatars
   enum UserAvatarFormat
     PNG
     JPEG
@@ -92,6 +99,7 @@ module Discord::CDN
     end
   end
 
+  # Available image formats for application icons
   enum ApplicationIconFormat
     PNG
     JPEG
@@ -124,6 +132,7 @@ module Discord::CDN
     end
   end
 
+  # Produces a CDN URL for a custom emoji in the given `format` and `size`
   def custom_emoji(id : UInt64 | Snowflake,
                    format : CustomEmojiFormat = CustomEmojiFormat::PNG,
                    size : Int32 = 128)
@@ -131,6 +140,7 @@ module Discord::CDN
     "#{BASE_URL}/emojis/#{id}.#{format}?size=#{size}"
   end
 
+  # Produces a CDN URL for a guild icon in the given `format` and `size`
   def guild_icon(id : UInt64 | Snowflake, icon : String,
                  format : GuildIconFormat = GuildIconFormat::WebP,
                  size : Int32 = 128)
@@ -138,6 +148,7 @@ module Discord::CDN
     "#{BASE_URL}/icons/#{id}/#{icon}.#{format}?size=#{size}"
   end
 
+  # Produces a CDN URL for a guild splash in the given `format` and `size`
   def guild_splash(id : UInt64 | Snowflake, splash : String,
                    format : GuildSplashFormat = GuildSplashFormat::WebP,
                    size : Int32 = 128)
@@ -145,11 +156,15 @@ module Discord::CDN
     "#{BASE_URL}/splashes/#{id}/#{splash}.#{format}?size=#{size}"
   end
 
+  # Produces a CDN URL for a default user avatar, calculated from the given
+  # discriminator value.
   def default_user_avatar(user_discriminator : String)
     index = user_discriminator.to_i % 5
     "#{BASE_URL}/embed/avatars/#{index}.png"
   end
 
+  # Produces a CDN URL for a user avatar in the given `size`. Given the `avatar`
+  # string, this will return a WebP or GIF based on the animated avatar hint.
   def user_avatar(id : UInt64 | Snowflake, avatar : String, size : Int32 = 128)
     if avatar.starts_with?("a_")
       user_avatar(id, avatar, UserAvatarFormat::GIF, size)
@@ -158,12 +173,14 @@ module Discord::CDN
     end
   end
 
+  # Produces a CDN URL for a user avatar in the given `format` and `size`
   def user_avatar(id : UInt64 | Snowflake, avatar : String,
                   format : UserAvatarFormat, size : Int32 = 128)
     check_size(size)
     "#{BASE_URL}/avatars/#{id}/#{avatar}.#{format}?size=#{size}"
   end
 
+  # Produces a CDN URL for an application icon in the given `format` and `size`
   def application_icon(id : UInt64 | Snowflake, icon : String,
                        format : ApplicationIconFormat = ApplicationIconFormat::WebP,
                        size : Int32 = 128)

--- a/src/discordcr/cdn.cr
+++ b/src/discordcr/cdn.cr
@@ -1,0 +1,173 @@
+# This module contains methods for building URLs to resources on Discord's CDN
+# for things like guild icons and avatars.
+#
+# [API Documentation for image formatting](https://discordapp.com/developers/docs/reference#image-formatting)
+module Discord::CDN
+  extend self
+
+  # Base CDN URL
+  BASE_URL = "https://cdn.discordapp.com"
+
+  enum CustomEmojiFormat
+    PNG
+    GIF
+
+    def to_s
+      case self
+      when PNG
+        "png"
+      when GIF
+        "gif"
+      end
+    end
+
+    def to_s(io : IO)
+      io << to_s
+    end
+  end
+
+  enum GuildIconFormat
+    PNG
+    JPEG
+    WebP
+
+    def to_s
+      case self
+      when PNG
+        "png"
+      when JPEG
+        "jpeg"
+      when WebP
+        "webp"
+      end
+    end
+
+    def to_s(io : IO)
+      io << to_s
+    end
+  end
+
+  enum GuildSplashFormat
+    PNG
+    JPEG
+    WebP
+
+    def to_s
+      case self
+      when PNG
+        "png"
+      when JPEG
+        "jpeg"
+      when WebP
+        "webp"
+      end
+    end
+
+    def to_s(io : IO)
+      io << to_s
+    end
+  end
+
+  enum UserAvatarFormat
+    PNG
+    JPEG
+    WebP
+    GIF
+
+    def to_s
+      case self
+      when PNG
+        "png"
+      when JPEG
+        "jpeg"
+      when WebP
+        "webp"
+      when GIF
+        "gif"
+      end
+    end
+
+    def to_s(io : IO)
+      io << to_s
+    end
+  end
+
+  enum ApplicationIconFormat
+    PNG
+    JPEG
+    WebP
+    GIF
+
+    def to_s
+      case self
+      when PNG
+        "png"
+      when JPEG
+        "jpeg"
+      when WebP
+        "webp"
+      when GIF
+        "gif"
+      end
+    end
+
+    def to_s(io : IO)
+      io << to_s
+    end
+  end
+
+  private def check_size(value : Int32)
+    in_range = (16..2048).includes?(value)
+    power_of_two = (value > 0) && ((value & (value - 1)) == 0)
+    unless in_range && power_of_two
+      raise ArgumentError.new("Size #{value} is not between 16 and 2048 and a power of 2")
+    end
+  end
+
+  def custom_emoji(id : UInt64 | Snowflake,
+                   format : CustomEmojiFormat = CustomEmojiFormat::PNG,
+                   size : Int32 = 128)
+    check_size(size)
+    "#{BASE_URL}/emojis/#{id}.#{format}?size=#{size}"
+  end
+
+  def guild_icon(id : UInt64 | Snowflake, icon : String,
+                 format : GuildIconFormat = GuildIconFormat::WebP,
+                 size : Int32 = 128)
+    check_size(size)
+    "#{BASE_URL}/icons/#{id}/#{icon}.#{format}?size=#{size}"
+  end
+
+  def guild_splash(id : UInt64 | Snowflake, splash : String,
+                   format : GuildSplashFormat = GuildSplashFormat::WebP,
+                   size : Int32 = 128)
+    check_size(size)
+    "#{BASE_URL}/splashes/#{id}/#{splash}.#{format}?size=#{size}"
+  end
+
+  def default_user_avatar(user_discriminator : String)
+    index = user_discriminator.to_i % 5
+    "#{BASE_URL}/embed/avatars/#{index}.png"
+  end
+
+  def user_avatar(id : UInt64 | Snowflake, avatar : String, size : Int32 = 128)
+    if avatar.starts_with?("a_")
+      user_avatar(id, avatar, UserAvatarFormat::GIF, size)
+    else
+      user_avatar(id, avatar, UserAvatarFormat::WebP, size)
+    end
+  end
+
+  def user_avatar(id : UInt64 | Snowflake, avatar : String,
+                  format : UserAvatarFormat, size : Int32 = 128)
+    check_size(size)
+    "#{BASE_URL}/avatars/#{id}/#{avatar}.#{format}?size=#{size}"
+  end
+
+  def application_icon(id : UInt64 | Snowflake, icon : String,
+                       format : ApplicationIconFormat = ApplicationIconFormat::WebP,
+                       size : Int32 = 128)
+    check_size(size)
+    "#{BASE_URL}/app-icons/#{id}/#{icon}.#{format}?size=#{size}"
+  end
+end

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -50,6 +50,20 @@ module Discord
         emoji
       end
     {% end %}
+
+    def icon_url(format : CDN::GuildIconFormat = CDN::GuildIconFormat::WebP,
+                 size : Int32 = 128)
+      if icon = @icon
+        CDN.guild_icon(id, icon, format, size)
+      end
+    end
+
+    def splash_url(format : CDN::GuildSplashFormat = CDN::GuildSplashFormat::WebP,
+                   size : Int32 = 128)
+      if splash = @splash
+        CDN.guild_splash(id, splash, format, size)
+      end
+    end
   end
 
   struct UnavailableGuild
@@ -140,6 +154,18 @@ module Discord
       managed: Bool,
       animated: Bool
     )
+
+    def image_url(size : Int32 = 128)
+      if animated
+        image_url(:gif, size)
+      else
+        image_url(:png, size)
+      end
+    end
+
+    def image_url(format : CDN::CustomEmojiFormat, size : Int32 = 128)
+      CDN.custom_emoji(id, format, size)
+    end
   end
 
   struct Role

--- a/src/discordcr/mappings/guild.cr
+++ b/src/discordcr/mappings/guild.cr
@@ -51,6 +51,8 @@ module Discord
       end
     {% end %}
 
+    # Produces a CDN URL to this guild's icon in the given `format` and `size`,
+    # or `nil` if no icon is set.
     def icon_url(format : CDN::GuildIconFormat = CDN::GuildIconFormat::WebP,
                  size : Int32 = 128)
       if icon = @icon
@@ -58,6 +60,8 @@ module Discord
       end
     end
 
+    # Produces a CDN URL to this guild's splash in the given `format` and `size`,
+    # or `nil` if no splash is set.
     def splash_url(format : CDN::GuildSplashFormat = CDN::GuildSplashFormat::WebP,
                    size : Int32 = 128)
       if splash = @splash
@@ -155,6 +159,8 @@ module Discord
       animated: Bool
     )
 
+    # Produces a CDN URL to this emoji's image in the given `size`. Will return
+    # a PNG, or GIF if the emoji is animated.
     def image_url(size : Int32 = 128)
       if animated
         image_url(:gif, size)
@@ -163,6 +169,7 @@ module Discord
       end
     end
 
+    # Produces a CDN URL to this emoji's image in the given `format` and `size`
     def image_url(format : CDN::CustomEmojiFormat, size : Int32 = 128)
       CDN.custom_emoji(id, format, size)
     end

--- a/src/discordcr/mappings/oauth2.cr
+++ b/src/discordcr/mappings/oauth2.cr
@@ -16,5 +16,12 @@ module Discord
       bot_require_code_grant: Bool,
       owner:                  User,
     })
+
+    def icon_url(format : CDN::ApplicationIconFormat = CDN::ApplicationIconFormat::WebP,
+                 size : Int32 = 128)
+      if icon = @icon
+        CDN.application_icon(id, icon, format, size)
+      end
+    end
   end
 end

--- a/src/discordcr/mappings/oauth2.cr
+++ b/src/discordcr/mappings/oauth2.cr
@@ -17,6 +17,7 @@ module Discord
       owner:                  User,
     })
 
+    # Produces a CDN URL for this application's icon in the given `format` and `size`
     def icon_url(format : CDN::ApplicationIconFormat = CDN::ApplicationIconFormat::WebP,
                  size : Int32 = 128)
       if icon = @icon

--- a/src/discordcr/mappings/user.cr
+++ b/src/discordcr/mappings/user.cr
@@ -22,6 +22,22 @@ module Discord
       mfa_enabled: Bool?,
       verified: Bool?
     )
+
+    def avatar_url(size : Int32 = 128)
+      if avatar = @avatar
+        CDN.user_avatar(id, avatar, size)
+      else
+        CDN.default_user_avatar(discriminator)
+      end
+    end
+
+    def avatar_url(format : CDN::UserAvatarFormat, size : Int32 = 128)
+      if avatar = @avatar
+        CDN.user_avatar(id, avatar, format, size)
+      else
+        CDN.default_user_avatar(discriminator)
+      end
+    end
   end
 
   struct PartialUser

--- a/src/discordcr/mappings/user.cr
+++ b/src/discordcr/mappings/user.cr
@@ -23,6 +23,10 @@ module Discord
       verified: Bool?
     )
 
+    # Produces a CDN URL to this user's avatar in the given `size`.
+    # If the user has an avatar a WebP will be returned, or a GIF
+    # if the avatar is animated. If the user has no avatar, a default
+    # avatar URL is returned.
     def avatar_url(size : Int32 = 128)
       if avatar = @avatar
         CDN.user_avatar(id, avatar, size)
@@ -31,6 +35,8 @@ module Discord
       end
     end
 
+    # Produces a CDN URL to this user's avatar, in the given `format` and
+    # `size`. If the user has no avatar, a default avatar URL is returned.
     def avatar_url(format : CDN::UserAvatarFormat, size : Int32 = 128)
       if avatar = @avatar
         CDN.user_avatar(id, avatar, format, size)


### PR DESCRIPTION
Should `Discord::User#avatar_url`, etc be created that wraps these functions, or perhaps `CDN.user_avatar(user : User)`?