### PR TITLE
Fix docs generation

### DIFF
--- a/src/discordcr/paginator.cr
+++ b/src/discordcr/paginator.cr
@@ -1,4 +1,3 @@
-# :nodoc:
 module Discord
   class Paginator(T)
     include ::Enumerable(T)


### PR DESCRIPTION
It seems like this caused docs to silently "fail"; hadn't noticed it as the docs tool was just keeping my old docs around I had already generated in previous commits.