### PR TITLE
Support zlib-stream gateway compression

### DIFF
--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -43,6 +43,18 @@ module Discord
       referring_domain: ""
     )
 
+    # Available gateway compression modes that can be requested
+    enum CompressMode
+      # Discord won't send any compressed data
+      None
+
+      # Large payloads (typically `GUILD_CREATE`) will be received compressed
+      Large
+
+      # All data will be received in a compressed stream
+      Stream
+    end
+
     # Creates a new bot with the given *token* and optionally the *client_id*.
     # Both of these things can be found on a bot's application page; the token
     # will need to be revealed using the "click to reveal" thing on the token
@@ -60,7 +72,11 @@ module Discord
     # uses; the maximum value is 250. To get a list of offline members as well,
     # the `#request_guild_members` method can be used.
     #
-    # If *compress* is true, packets will be sent in a compressed manner.
+    # `compress` can be set to any value of `CompressMode`. `CompressMode::Stream`
+    # is the default and will save the most bandwidth. You can optionally change
+    # this to `CompressMode::Large` to request that only large payloads be received
+    # compressed. Compression can be disabled with `CompressMode::None`, but this
+    # is not recommended for production bots.
     #
     # The *properties* define what values are sent to Discord as analytics
     # properties. It's not recommended to change these from the default values,
@@ -68,7 +84,7 @@ module Discord
     def initialize(@token : String, @client_id : UInt64? = nil,
                    @shard : Gateway::ShardKey? = nil,
                    @large_threshold : Int32 = 100,
-                   @compress : Bool = true,
+                   @compress : CompressMode = CompressMode::Stream,
                    @properties : Gateway::IdentifyProperties = DEFAULT_PROPERTIES,
                    @logger = Logger.new(STDOUT))
       @logger.progname = "discordcr"
@@ -145,16 +161,30 @@ module Discord
 
     private def initialize_websocket : Discord::WebSocket
       url = URI.parse(get_gateway.url)
+
+      if @compress.stream?
+        path = "#{url.path}/?encoding=json&v=6&compress=zlib-stream"
+      else
+        path = "#{url.path}/?encoding=json&v=6"
+      end
+
       websocket = Discord::WebSocket.new(
         host: url.host.not_nil!,
-        path: "#{url.path}/?encoding=json&v=6",
+        path: path,
         port: 443,
         tls: true,
         logger: @logger
       )
 
       websocket.on_message(&->on_message(Discord::WebSocket::Packet))
-      websocket.on_binary(&->on_message(Discord::WebSocket::Packet))
+
+      case @compress
+      when .large?
+        websocket.on_compressed(&->on_message(Discord::WebSocket::Packet))
+      when .stream?
+        websocket.on_compressed_stream(&->on_message(Discord::WebSocket::Packet))
+      end
+
       websocket.on_close(&->on_close(String))
 
       websocket
@@ -285,7 +315,8 @@ module Discord
         shard_tuple = shard.values
       end
 
-      packet = Gateway::IdentifyPacket.new(@token, @properties, @compress, @large_threshold, shard_tuple)
+      compress = @compress.large?
+      packet = Gateway::IdentifyPacket.new(@token, @properties, compress, @large_threshold, shard_tuple)
       websocket.send(packet.to_json)
     end
 

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -78,6 +78,9 @@ module Discord
     # compressed. Compression can be disabled with `CompressMode::None`, but this
     # is not recommended for production bots.
     #
+    # When using `Compress::Stream` compression, the buffer size can be configured
+    # by passing `zlib_buffer_size`.
+    #
     # The *properties* define what values are sent to Discord as analytics
     # properties. It's not recommended to change these from the default values,
     # but if you desire to do so, you can.
@@ -85,6 +88,7 @@ module Discord
                    @shard : Gateway::ShardKey? = nil,
                    @large_threshold : Int32 = 100,
                    @compress : CompressMode = CompressMode::Stream,
+                   @zlib_buffer_size : Int32 = 10 * 1024 * 1024,
                    @properties : Gateway::IdentifyProperties = DEFAULT_PROPERTIES,
                    @logger = Logger.new(STDOUT))
       @logger.progname = "discordcr"
@@ -173,7 +177,8 @@ module Discord
         path: path,
         port: 443,
         tls: true,
-        logger: @logger
+        logger: @logger,
+        zlib_buffer_size: @zlib_buffer_size
       )
 
       websocket.on_message(&->on_message(Discord::WebSocket::Packet))


### PR DESCRIPTION
This PR adds support for Discord's `zlib-stream` compression transport mode. (Ref #10 )

## Background

Initially I had a ton of difficulty with this because the stdlib's `Zlib::Reader` basically isn't meant to do this; It is really just meant to do one-shot inflation.

The first issue is that when you `Reader.new(io)`, it immediately tries to consume the zlib header from that IO. This isn't helpful for us because we basically need a single instance of a `Reader` to keep around forever, and having `@reader : Reader?` is annoying.

~~To fix this, I've subclassed `Zlib::Reader` into `Zlib::StreamReader` that lets us control when we read the header - *only* on the very first binary frame we receive, letting us keep a single instance around. I've made an instance method that calls `Zlib::Reader.read_header` as it is `protected`.~~

\* - **See updated diff; we now lazily initialize the stdlib `Zlib::Reader`**

Next, if you just pass `Object.from_json(zlib_reader)`, this will deadlock the program. The *entire* program as far as I can tell. Example: https://github.com/z64/zlib-freeze

\* - **Upstream issue:** https://github.com/crystal-lang/crystal/issues/6575

This doesn't happen if you `reader.read(slice)`. So I've created a single 10MB  `Bytes` buffer (referencing b1nzy's [disco implementation](https://github.com/b1naryth1ef/disco/blob/master/disco/gateway/client.py#L178)) specifically to throw the inflated JSON into, which we can then wrap in an IO and pass to our objects.

Lastly, to avoid a mess of a single binary handler, I've split our `on_binary` into two methods: `on_compressed` for the basic "large" compression mode, and `on_compressed_stream` for `zlib-stream` frames that both register their own `@websocket.on_binary` handlers respectively.

## Interface

`compressed` in `Client#initialize` is now an enum instead of bool:
```cr
client = Discord::Client.new(token: "token", compress: :none)
client = Discord::Client.new(token: "token", compress: :large)
client = Discord::Client.new(token: "token", compress: :stream)
```

`CompressMode::Stream` is now the default, as it has the most bandwidth savings, and per rumor, might be required for the next major gateway version.

The appropriate callbacks and IDENTIFY payloads are configured by checking `@compress.large?` and `@compress.stream?`. 

I've had a bot running with this `zlib-stream` code for about 12 hours without issue, but please feel free to test this on your own.