### PR TITLE
Fix REST#delete_guild_role expecting a Role object response

### DIFF
--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -1132,7 +1132,7 @@ module Discord
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/guild#delete-guild-role)
     def delete_guild_role(guild_id : UInt64 | Snowflake, role_id : UInt64 | Snowflake)
-      response = request(
+      request(
         :guilds_gid_roles_rid,
         guild_id,
         "DELETE",
@@ -1140,8 +1140,6 @@ module Discord
         HTTP::Headers.new,
         nil
       )
-
-      Role.from_json(response.body)
     end
 
     # Get a number of members that would be pruned with the given number of


### PR DESCRIPTION
This endpoint returns a 204 upon success, not the deleted role.