### PR TITLE
Fix @client_id must be UInt64 not Snowflake

### DIFF
--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -84,7 +84,7 @@ module Discord
     # The *properties* define what values are sent to Discord as analytics
     # properties. It's not recommended to change these from the default values,
     # but if you desire to do so, you can.
-    def initialize(@token : String, @client_id : UInt64? = nil,
+    def initialize(@token : String, @client_id : (UInt64 | Snowflake)? = nil,
                    @shard : Gateway::ShardKey? = nil,
                    @large_threshold : Int32 = 100,
                    @compress : CompressMode = CompressMode::Stream,

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -84,7 +84,7 @@ module Discord
     # The *properties* define what values are sent to Discord as analytics
     # properties. It's not recommended to change these from the default values,
     # but if you desire to do so, you can.
-    def initialize(@token : String, @client_id : (UInt64 | Snowflake)? = nil,
+    def initialize(@token : String, @client_id : UInt64 | Snowflake | Nil = nil,
                    @shard : Gateway::ShardKey? = nil,
                    @large_threshold : Int32 = 100,
                    @compress : CompressMode = CompressMode::Stream,


### PR DESCRIPTION
```
in lib/discordcr/src/discordcr/client.cr:118: 
instance variable '@client_id' of Discord::Client must be (UInt64 | Nil), not Discord::Snowflake
  @client_id ||= get_oauth2_application.id
```