### PR TITLE
Use monotonic clock in Discord.timed_run

### DIFF
--- a/src/discordcr/voice.cr
+++ b/src/discordcr/voice.cr
@@ -284,9 +284,7 @@ module Discord
   # one frame every 20 ms, and if the processing and sending takes a certain
   # amount of time, then noticeable choppiness can be heard.
   def self.timed_run(total_time : Time::Span)
-    time = Time.monotonic
-    yield
-    delta = Time.monotonic - time
+    delta = Time.measure { yield }
 
     sleep_time = {total_time - delta, Time::Span.zero}.max
     sleep sleep_time

--- a/src/discordcr/voice.cr
+++ b/src/discordcr/voice.cr
@@ -284,9 +284,9 @@ module Discord
   # one frame every 20 ms, and if the processing and sending takes a certain
   # amount of time, then noticeable choppiness can be heard.
   def self.timed_run(total_time : Time::Span)
-    t1 = Time.now
+    time = Time.monotonic
     yield
-    delta = Time.now - t1
+    delta = Time.monotonic - time
 
     sleep_time = {total_time - delta, Time::Span.zero}.max
     sleep sleep_time


### PR DESCRIPTION
This uses the monotonic clock instead of the current time in `Discord.timed_run` which is more accurate since it's unaffected by time fluctuations such as leap seconds or manually changing the computer time.