### PR TITLE
Fix DM channels from not being cached 

### DIFF
--- a/src/discordcr/cache.cr
+++ b/src/discordcr/cache.cr
@@ -129,7 +129,7 @@ module Discord
       @dm_channels.fetch(recipient_id) do
         channel = @client.create_dm(recipient_id)
         cache(Channel.new(channel))
-        channel.id.to_u64
+        @dm_channels[recipient_id] = channel.id.to_u64
       end
     end
 

--- a/src/discordcr/client.cr
+++ b/src/discordcr/client.cr
@@ -447,7 +447,7 @@ module Discord
         recipients = payload.recipients
         if guild_id
           @cache.try &.add_guild_channel(guild_id, payload.id)
-        elsif payload.type == 1 && recipients
+        elsif payload.type.dm? && recipients
           @cache.try &.cache_dm_channel(payload.id, recipients[0].id)
         end
 


### PR DESCRIPTION
Fixes DM channels not being cached

- Use ChannelType#dm? to check if we should cache a dm_channel

- Correct usage of Hash#fetch in resolve_dm_channel