### PR TITLE
Fix edit_channel_permissions' docs and add missing permissions

### DIFF
--- a/src/discordcr/mappings/permissions.cr
+++ b/src/discordcr/mappings/permissions.cr
@@ -8,6 +8,8 @@ module Discord
     ManageChannels      = 1 << 4
     ManageGuild         = 1 << 5
     AddReactions        = 1 << 6
+    ViewAuditLog        = 1 << 7
+    PrioritySpeaker     = 1 << 8
     ReadMessages        = 1 << 10
     SendMessages        = 1 << 11
     SendTTSMessages     = 1 << 12
@@ -30,8 +32,6 @@ module Discord
     ManageEmojis        = 1 << 30
 
     def self.new(pull : JSON::PullParser)
-      # see https://github.com/crystal-lang/crystal/issues/3448
-      # #from_value errors
       Permissions.new(pull.read_int.to_u64)
     end
   end

--- a/src/discordcr/rest.cr
+++ b/src/discordcr/rest.cr
@@ -471,7 +471,7 @@ module Discord
 
     # Edits an existing permission overwrite on a channel with new permissions,
     # or creates a new one. The *overwrite_id* should be either a user or a role
-    # ID. Requires the "Manage Permissions" permission.
+    # ID. Requires the "Manage Roles" permission.
     #
     # [API docs for this method](https://discordapp.com/developers/docs/resources/channel#edit-channel-permissions)
     def edit_channel_permissions(channel_id : UInt64 | Snowflake, overwrite_id : UInt64 | Snowflake,


### PR DESCRIPTION
This fixes a wrong permission in [`edit_channel_permissions`](https://meew0.github.io/discordcr/doc/master/Discord/REST.html#edit_channel_permissions(channel_id:UInt64|Snowflake,overwrite_id:UInt64|Snowflake,type:String,allow:Permissions,deny:Permissions)-instance-method)' docs and removes the comment in `Permissions.new` (see https://github.com/meew0/discordcr/pull/174#issuecomment-447901908).
It also adds 2 missing permissions to the `Permissions` enum.