### PR TITLE
remove slash in log to exlude double slash from log output

### DIFF
--- a/src/discordcr/websocket.cr
+++ b/src/discordcr/websocket.cr
@@ -60,7 +60,7 @@ module Discord
 
     def initialize(@host : String, @path : String, @port : Int32, @tls : Bool,
                    @zlib_buffer_size : Int32 = 10 * 1024 * 1024)
-      Log.info { "Connecting to #{@host}/#{@path}:#{@port}" }
+      Log.info { "Connecting to #{@host}#{@path}:#{@port}" }
       @websocket = HTTP::WebSocket.new(
         host: @host,
         path: @path,


### PR DESCRIPTION
Either `@host : String, @path : String` already contains a `/`, therefore the extra one in the log doesn't seem to be needed :)

![image](https://user-images.githubusercontent.com/6486417/81507765-0ef9d000-92da-11ea-88d5-470be0c30ac7.png)

before ^ (sad)

![image](https://user-images.githubusercontent.com/6486417/81507790-351f7000-92da-11ea-9efd-778777ccc5f7.png)

after ^ (happy!)